### PR TITLE
fix: generated secret name should follow release name

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -41,4 +41,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.15.1
+version: 2.15.2

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -18,7 +18,7 @@ Returns a secret name for service to service auth
     {{- if .Values.global.auth.backend.existingSecret -}}
         {{- .Values.global.auth.backend.existingSecret -}}
     {{- else -}}
-        {{- include "common.names.fullname" . -}}-auth
+        {{- printf "%s-auth" .Release.Name -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-auth
+  name: {{ printf "%s-auth" .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage


### PR DESCRIPTION
The generated backend auth secret and the values.yaml file seem to be run under different contexts which will not allow the use of `common.names.fullname` to get the name of the current release of the chart. The secret will always grab the name of the redhat-developer-hub chart. So instead we should use the `.Release.Name` which will always be the release name for both.

