### PR TITLE
chore(ci): remove superfluous 'Install Oras' step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
 
-      - name: Install Oras
-        uses: oras-project/setup-oras@ee7dbe1144cb00080a89497f937dae78f85fce29 # v1.1.0
-
       - name: Publish and Sign OCI Charts
         run: |
           for chart in `find .cr-release-packages -name '*.tgz' -print`; do


### PR DESCRIPTION
## Description of the change

Removes superfluous 'Install Oras' step - according to https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools this is bundled by default in all Ubuntu GitHub Actions runners.

Also cited in https://github.com/oras-project/setup-oras/issues/17

## Existing or Associated Issue(s)

This is in effort to mitigate the following warning - we may as well use the bundled version so we pick up updates when GitHub applies them:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: oras-project/setup-oras@ee7dbe1144cb00080a89497f937dae78f85fce29. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

## Additional Information


## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
