### PR TITLE
fix: Jinja auto-escape is set to false

### DIFF
--- a/.pre-commit/jsonschema-dereference.py
+++ b/.pre-commit/jsonschema-dereference.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import jsonref
 import yaml
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Loader
 from jinja2 import Template
 
 JSONSCHEMA_TEMPLATE_NAME = "values.schema.tmpl.json"
@@ -17,56 +17,50 @@ CHART_LOCK = "Chart.lock"
 
 def read_yaml(file_path: Path):
     """Open and load Chart.yaml file."""
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         return yaml.load(f, Loader=Loader)
 
-def template_schema(chart_dir: Path, lock: Dict[str, Any]):
+def template_schema(chart_dir: Path, my_lock: Dict[str, Any]):
     """Load values.schema.tmpl.json and template it via Jinja2."""
-    with open(chart_dir / JSONSCHEMA_TEMPLATE_NAME, "r") as f:
-        schema_template = Template(f.read(), autoescape=True)
+    with open(chart_dir / JSONSCHEMA_TEMPLATE_NAME, "r", encoding="utf-8") as f:
+        my_schema_template = Template(f.read(), autoescape=True)
 
-    return json.loads(schema_template.render(lock))
+    return json.loads(my_schema_template.render(my_lock))
 
-def tidy_schema(schema: Any, values: Any):
+def tidy_schema(my_schema: Any, my_values: Any):
     """Hack to support OCP Form view.
 
     https://issues.redhat.com/browse/OCPBUGS-14874
     https://issues.redhat.com/browse/OCPBUGS-14875
     """
-    if isinstance(schema, dict):
-        try:
-            del schema["$schema"]
-        except:
-            pass
-        try:
-            del schema["format"]
-        except:
-            pass
+    if isinstance(my_schema, dict):
+        my_schema.pop("$schema", None)
+        my_schema.pop("format", None)
 
         # Override existing defaults so OCP form view
         # doesn't try to override our defaults
-        if schema.get("default") is not None and values is not None:
-            schema["default"] = values
+        if my_schema.get("default") is not None and my_values is not None:
+            my_schema["default"] = my_values
 
         # Tidy up properties for type: object
-        properties: Dict[str, Any] = schema.get("properties", {})
+        properties: Dict[str, Any] = my_schema.get("properties", {})
         for k, v in properties.items():
-            if isinstance(values, dict):
-                new_values = values.get(k, None)
+            if isinstance(my_values, dict):
+                new_values = my_values.get(k, None)
             else:
                 new_values = None
             tidy_schema(v, new_values)
 
         # Tidy up properties for type: array
-        items: Dict[str, Any] = schema.get("items", {})
+        items: Dict[str, Any] = my_schema.get("items", {})
         if items:
-            tidy_schema(items, values)
-    return schema
+            tidy_schema(items, my_values)
+    return my_schema
 
-def save(chart_dir: Path, schema: Any):
+def save(chart_dir: Path, my_schema: Any):
     """Take schema containing $refs and dereference them."""
-    with open(chart_dir / JSONSCHEMA_NAME, "w") as f:
-        json.dump(schema, f, indent=4, sort_keys=True)
+    with open(chart_dir / JSONSCHEMA_NAME, "w", encoding="utf-8") as f:
+        json.dump(my_schema, f, indent=4, sort_keys=True)
 
 if __name__ == '__main__':
     charts = [p.parent for p in Path(".").rglob(CHART_LOCK)]

--- a/.pre-commit/jsonschema-dereference.py
+++ b/.pre-commit/jsonschema-dereference.py
@@ -23,7 +23,7 @@ def read_yaml(file_path: Path):
 def template_schema(chart_dir: Path, lock: Dict[str, Any]):
     """Load values.schema.tmpl.json and template it via Jinja2."""
     with open(chart_dir / JSONSCHEMA_TEMPLATE_NAME, "r") as f:
-        schema_template = Template(f.read())
+        schema_template = Template(f.read(), autoescape=True)
 
     return json.loads(schema_template.render(lock))
 

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.16.2
+version: 2.16.3

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,18 +2,20 @@
 # RHDH Backstage Helm Chart for OpenShift
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.16.3(https://img.shields.io/badge/Version-2.16.3-informational?style=flat-square)
+![Version: 2.16.3](https://img.shields.io/badge/Version-2.16.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-A Helm chart for deploying RHDH (a Backstage application)
+A Helm chart for deploying Red Hat Developer Hub.
+
+The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.2/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh
 
 **Homepage:** <https://redhat-developer.github.io/rhdh-chart/>
 
 ## Maintainers
 
-| Name | Url |
-| ---- | --- |
-| Red Hat Developer Hub Team | <https://github.com/redhat-developer/rhdh-chart> |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Red Hat Developer Hub Team |  | <https://github.com/redhat-developer/rhdh-chart> |
 
 ## Source Code
 
@@ -111,10 +113,10 @@ helm upgrade -i <release_name> oci://ghcr.io/redhat-developer/rhdh-chart/backsta
 
 ### Uninstalling the Chart
 
-To uninstall/delete the `my-backstage` deployment:
+To uninstall/delete the `my-backstage-release` deployment:
 
 ```console
-helm uninstall my-backstage
+helm uninstall my-backstage-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -127,10 +129,6 @@ Kubernetes: `>= 1.25.0-0`
 |------------|------|---------|
 | https://backstage.github.io/charts | upstream(backstage) | 1.9.1 |
 | https://charts.bitnami.com/bitnami | common | 2.14.1 |
-
-## Telemetry data collection
-
-The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.2/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh
 
 ## Values
 
@@ -145,7 +143,7 @@ The telemetry data collection feature is enabled by default. Red Hat Developer H
 | global.dynamic.includes | Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field. Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`). | list | `["dynamic-plugins.default.yaml"]` |
 | global.dynamic.includes[0] | List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default. This file ONLY works with the `janus-idp/backstage-showcase` container image. | string | `"dynamic-plugins.default.yaml"` |
 | global.dynamic.plugins | List of dynamic plugins, possibly overriding the plugins listed in `includes` files. Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec), an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `disabled` flag to disable/enable a plugin listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description). | list | `[]` |
-| global.host | Custom hostname shorthand, overrides `global.clusterRouterBase`, `upstream.ingress.host`, `route.host`, and url values in `upstream.backstage.appConfig`.  | string | `""` |
+| global.host | Custom hostname shorthand, overrides `global.clusterRouterBase`, `upstream.ingress.host`, `route.host`, and url values in `upstream.backstage.appConfig`. | string | `""` |
 | route | OpenShift Route parameters | object | `{"annotations":{},"enabled":true,"host":"{{ .Values.global.host }}","path":"/","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}` |
 | route.annotations | Route specific annotations | object | `{}` |
 | route.enabled | Enable the creation of the route resource | bool | `true` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.16.2](https://img.shields.io/badge/Version-2.16.2-informational?style=flat-square)
+![Version: 2.16.3(https://img.shields.io/badge/Version-2.16.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying RHDH (a Backstage application)

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -2526,6 +2526,10 @@
                                 {
                                     "mountPath": "/opt/app-root/src/dynamic-plugins-root",
                                     "name": "dynamic-plugins-root"
+                                },
+                                {
+                                    "mountPath": "/opt/app-root/src/packages/app/dist/static",
+                                    "name": "diststatic"
                                 }
                             ],
                             "items": {
@@ -2599,6 +2603,14 @@
                                         "optional": true,
                                         "secretName": "dynamic-plugins-npmrc"
                                     }
+                                },
+                                {
+                                    "emptyDir": {},
+                                    "name": "npmcacache"
+                                },
+                                {
+                                    "emptyDir": {},
+                                    "name": "diststatic"
                                 }
                             ],
                             "items": {
@@ -4180,6 +4192,30 @@
                                     "image": "{{ include \"backstage.image\" . }}",
                                     "imagePullPolicy": "Always",
                                     "name": "install-dynamic-plugins",
+                                    "resources": {
+                                        "limits": {
+                                            "cpu": "1000m",
+                                            "ephemeral-storage": "5Gi",
+                                            "memory": "2.5Gi"
+                                        },
+                                        "requests": {
+                                            "cpu": "250m",
+                                            "memory": "256Mi"
+                                        }
+                                    },
+                                    "securityContext": {
+                                        "allowPrivilegeEscalation": false,
+                                        "capabilities": {
+                                            "drop": [
+                                                "ALL"
+                                            ]
+                                        },
+                                        "readOnlyRootFilesystem": true,
+                                        "runAsNonRoot": true,
+                                        "seccompProfile": {
+                                            "type": "RuntimeDefault"
+                                        }
+                                    },
                                     "volumeMounts": [
                                         {
                                             "mountPath": "/dynamic-plugins-root",
@@ -4196,6 +4232,10 @@
                                             "name": "dynamic-plugins-npmrc",
                                             "readOnly": true,
                                             "subPath": ".npmrc"
+                                        },
+                                        {
+                                            "mountPath": "/opt/app-root/src/.npm/_cacache",
+                                            "name": "npmcacache"
                                         }
                                     ],
                                     "workingDir": "/opt/app-root/src"


### PR DESCRIPTION
jinja2.Template is called with no autoescape argument (autoescaping is disabled by default). This increases
 the risk of Cross-Site Scripting (XSS) attacks.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
