### PR TITLE
fix: RHIDP-2974: Revert readOnlyRootFilesystem in values.yaml

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.16.3
+version: 2.16.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.16.3](https://img.shields.io/badge/Version-2.16.3-informational?style=flat-square)
+![Version: 2.16.4](https://img.shields.io/badge/Version-2.16.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -4210,7 +4210,6 @@
                                                 "ALL"
                                             ]
                                         },
-                                        "readOnlyRootFilesystem": true,
                                         "runAsNonRoot": true,
                                         "seccompProfile": {
                                             "type": "RuntimeDefault"

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -66,7 +66,6 @@ upstream:
       capabilities:
         drop: ["ALL"]
       runAsNonRoot: true
-      readOnlyRootFilesystem: true
       seccompProfile:
         type: "RuntimeDefault"
     resources:
@@ -165,7 +164,6 @@ upstream:
           capabilities:
             drop: ["ALL"]
           runAsNonRoot: true
-          readOnlyRootFilesystem: true
           seccompProfile:
             type: "RuntimeDefault"
         # -- Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount.


### PR DESCRIPTION
Backstage injects the config into a javascript file in the dist/static directory in the running instance, which is part of the root filesystem. Until we can fix this we will need the root filesystem to be writable

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
