### PR TITLE
chore: RHIDP-3048: Add release name to dynamic-plugins configmap name

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.16.5
+version: 2.16.6

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.16.5](https://img.shields.io/badge/Version-2.16.5-informational?style=flat-square)
+![Version: 2.16.6](https://img.shields.io/badge/Version-2.16.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/templates/dynamic-plugins-configmap.yaml
+++ b/charts/backstage/templates/dynamic-plugins-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dynamic-plugins
+  name: {{ printf "%s-dynamic-plugins" .Release.Name }}
 data:
   dynamic-plugins.yaml: |
     {{- include "common.tplvalues.render" ( dict "value"

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -2587,7 +2587,7 @@
                                 {
                                     "configMap": {
                                         "defaultMode": 420,
-                                        "name": "dynamic-plugins",
+                                        "name": "{{ printf \"%s-dynamic-plugins\" .Release.Name }}",
                                         "optional": true
                                     },
                                     "name": "dynamic-plugins"

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -134,7 +134,7 @@ upstream:
       - name: dynamic-plugins
         configMap:
           defaultMode: 420
-          name: dynamic-plugins
+          name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
           optional: true
       # Optional volume that allows exposing the `.npmrc` file (through a `dynamic-plugins-npmrc` secret)
       # to be used when running `npm pack` during the dynamic plugins installation by the initContainer.


### PR DESCRIPTION
The dynamic-plugins configmap currently has a hard-coded name of 'dynamic-plugins' which prevents having two Developer Hub installations in the same namespace.

This pull request updates the name of the 'dynamic-plugins' configmap to include the name of the release such as '<release>-dynamic-plugins' which will alleviate this issue and allow multiple installations of Developer Hub per namespace using Helm.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

https://issues.redhat.com/browse/RHIDP-3048

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
