### PR TITLE
Add volumeMount for dynamic-plugins-registry-auth

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.18.0
+version: 2.19.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.18.0](https://img.shields.io/badge/Version-2.18.0-informational?style=flat-square)
+![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -2604,6 +2604,14 @@
                                     }
                                 },
                                 {
+                                    "name": "dynamic-plugins-registry-auth",
+                                    "secret": {
+                                        "defaultMode": 416,
+                                        "optional": true,
+                                        "secretName": "{{ printf \"%s-dynamic-plugins-registry-auth\" .Release.Name }}"
+                                    }
+                                },
+                                {
                                     "emptyDir": {},
                                     "name": "npmcacache"
                                 }
@@ -4226,6 +4234,11 @@
                                             "name": "dynamic-plugins-npmrc",
                                             "readOnly": true,
                                             "subPath": ".npmrc"
+                                        },
+                                        {
+                                            "mountPath": "/opt/app-root/src/.config/containers",
+                                            "name": "dynamic-plugins-registry-auth",
+                                            "readOnly": true
                                         },
                                         {
                                             "mountPath": "/opt/app-root/src/.npm/_cacache",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -142,6 +142,13 @@ upstream:
           defaultMode: 420
           optional: true
           secretName: '{{ printf "%s-dynamic-plugins-npmrc" .Release.Name }}'
+      # Optional volume that allows adding a container registry `auth.json` file (through a `dynamic-plugins-registry-auth` secret)
+      # to be used when installing plugins from secure container registries during the dynamic plugins installation by the initContainer.
+      - name: dynamic-plugins-registry-auth
+        secret:
+          defaultMode: 416
+          optional: true
+          secretName: '{{ printf "%s-dynamic-plugins-registry-auth" .Release.Name }}'
       - name: npmcacache
         emptyDir: {}
     initContainers:
@@ -183,6 +190,9 @@ upstream:
             name: dynamic-plugins-npmrc
             readOnly: true
             subPath: .npmrc
+          - mountPath: /opt/app-root/src/.config/containers
+            name: dynamic-plugins-registry-auth
+            readOnly: true
           - mountPath: /opt/app-root/src/.npm/_cacache
             name: npmcacache
         workingDir: /opt/app-root/src


### PR DESCRIPTION
For secure container registry we need a `auth.json` file that contains auth tokens. The file is stored as a secret like

```
oc create secret generic dynamic-plugins-registry-auth --from-file=~/.config/containers/auth.json
```

It is then picked up by `skopeo` during the dynamic plugin install process.

Accompanying PR for dynamic plugins:

https://github.com/janus-idp/backstage-showcase/pull/1479