### PR TITLE
fix: RHDHBUGS-98: Update audit log persistent volume mount path

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.20.0
+version: 2.20.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.20.0](https://img.shields.io/badge/Version-2.20.0-informational?style=flat-square)
+![Version: 2.20.1](https://img.shields.io/badge/Version-2.20.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -954,6 +954,11 @@
                                 "app": {
                                     "baseUrl": "https://{{- include \"janus-idp.hostname\" . }}"
                                 },
+                                "auditLog": {
+                                    "rotateFile": {
+                                        "enabled": true
+                                    }
+                                },
                                 "backend": {
                                     "auth": {
                                         "externalAccess": [
@@ -2532,7 +2537,7 @@
                                     "name": "dynamic-plugins-root"
                                 },
                                 {
-                                    "mountPath": "/var/log/audit",
+                                    "mountPath": "/var/log/redhat-developer-hub/audit",
                                     "name": "audit-log-data"
                                 }
                             ],

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -47,6 +47,9 @@ upstream:
     # create multiple DBs. Since Backstage requires by default 5 different DBs, we
     # can't accommodate that properly.
     appConfig:
+      auditLog:
+        rotateFile:
+          enabled: true
       app:
         # Please update to match host in case you don't want to configure hostname via `global.clusterRouterBase` or `global.host` if not deploying on an openshift cluster.
         baseUrl: 'https://{{- include "janus-idp.hostname" . }}'
@@ -120,7 +123,7 @@ upstream:
         mountPath: /opt/app-root/src/dynamic-plugins-root
       # Audit Log data will be stored in this volume mount.
       - name: audit-log-data
-        mountPath: /var/log/audit
+        mountPath: /var/log/redhat-developer-hub/audit
     extraVolumes:
       - name: dynamic-plugins-root
         persistentVolumeClaim:


### PR DESCRIPTION
Update the audit log persistent volume mount path to be consistent with the path that the audit logs are being written to by default https://github.com/janus-idp/backstage-showcase/blob/main/packages/backend/src/logger/customLogger.ts#L68-L70

I have manually tested this via Clean Install and Upgrade from previous non-working Helm Install and both showed the correct behavior without any upgrade errors.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
