### PR TITLE
feat: add support for exposing OpenTelemetry metrics

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.21.0
+version: 2.22.0

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.22.0
+version: 2.23.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.22.0](https://img.shields.io/badge/Version-2.22.0-informational?style=flat-square)
+![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.21.0](https://img.shields.io/badge/Version-2.21.0-informational?style=flat-square)
+![Version: 2.22.0](https://img.shields.io/badge/Version-2.22.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -6613,7 +6613,7 @@
                                             "type": "integer"
                                         }
                                     ],
-                                    "default": "http-backend",
+                                    "default": "http-metrics",
                                     "description": "The port where the metrics are exposed. If using OpenTelemetry as [documented here](https://backstage.io/docs/tutorials/setup-opentelemetry/), then the port needs to be explicitely specificed. OpenTelemetry's default port is 9464.",
                                     "title": "ServiceMonitor endpoint port"
                                 }
@@ -7221,7 +7221,13 @@
                             "type": "string"
                         },
                         "extraPorts": {
-                            "default": [],
+                            "default": [
+                                {
+                                    "name": "http-metrics",
+                                    "port": 9464,
+                                    "targetPort": 9464
+                                }
+                            ],
                             "items": {
                                 "type": "object"
                             },

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -206,6 +206,13 @@ upstream:
       checksum/dynamic-plugins: >-
         {{- include "common.tplvalues.render" ( dict "value"
         .Values.global.dynamic "context" $) | sha256sum }}
+  ingress:
+    host: "{{ .Values.global.host }}"
+  metrics:
+    serviceMonitor:
+      enabled: false
+      path: /metrics
+      port: http-metrics
   postgresql:
     enabled: true
     postgresqlDataDir: /var/lib/pgsql/data/userdata
@@ -241,8 +248,11 @@ upstream:
             secretKeyRef:
               key: postgres-password
               name: '{{- include "postgresql.v1.secretName" . }}'
-  ingress:
-    host: "{{ .Values.global.host }}"
+  service:
+    extraPorts:
+      - name: http-metrics
+        port: 9464
+        targetPort: 9464
 
 # -- OpenShift Route parameters
 route:


### PR DESCRIPTION
## Description of the change

Adds extra port to expose the metrics reported by OpenTelemetry
* Note that the metrics are disabled by default

## Existing or Associated Issue(s)

[RHIDP-4912](https://issues.redhat.com/browse/RHIDP-4912)

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
