### PR TITLE
fix: adjust startup, liveness and readiness probes settings

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.24.0
+version: 2.24.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.24.0](https://img.shields.io/badge/Version-2.24.0-informational?style=flat-square)
+![Version: 2.24.1](https://img.shields.io/badge/Version-2.24.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -81,26 +81,38 @@ upstream:
         cpu: 1000m
         memory: 2.5Gi
         ephemeral-storage: 5Gi
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 60
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
     readinessProbe:
       failureThreshold: 3
       httpGet:
-        path: /healthcheck
-        port: 7007
+        path: /.backstage/health/v1/readiness
+        port: backend
         scheme: HTTP
-      initialDelaySeconds: 30
+      # initialDelaySeconds: 30
       periodSeconds: 10
       successThreshold: 2
-      timeoutSeconds: 2
+      timeoutSeconds: 4
     livenessProbe:
       failureThreshold: 3
       httpGet:
-        path: /healthcheck
-        port: 7007
+        path: /.backstage/health/v1/liveness
+        port: backend
         scheme: HTTP
-      initialDelaySeconds: 60
+      # initialDelaySeconds: 60
       periodSeconds: 10
       successThreshold: 1
-      timeoutSeconds: 2
+      timeoutSeconds: 4
     extraEnvVars:
       - name: BACKEND_SECRET
         valueFrom:

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -99,6 +99,10 @@ upstream:
         path: /.backstage/health/v1/readiness
         port: backend
         scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
       # initialDelaySeconds: 30
       periodSeconds: 10
       successThreshold: 2
@@ -109,6 +113,10 @@ upstream:
         path: /.backstage/health/v1/liveness
         port: backend
         scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
       # initialDelaySeconds: 60
       periodSeconds: 10
       successThreshold: 1

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -88,7 +88,7 @@ upstream:
         path: /.backstage/health/v1/liveness
         port: backend
         scheme: HTTP
-      initialDelaySeconds: 60
+      initialDelaySeconds: 30
       timeoutSeconds: 4
       periodSeconds: 20
       successThreshold: 1


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Startup probe settings seem to have been added in the upstream Backstage Chart
in [1], but the current settings do not allow the RHDH Chart for the
liveness probe to be triggered sufficiently enough for the app to be
considered live.
This adjust such settings by accounting for the worst case scenario
where the application might take a bit long to start.

This also aligns the probe endpoints with the upstream chart.

[1] backstage/charts#216

## Existing or Associated Issue(s)

- Fixes https://issues.redhat.com/browse/RHIDP-5106
- Relates to https://issues.redhat.com/browse/RHIDP-4968

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
