### PR TITLE
fix: adjust startup, liveness and readiness...

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: |
   A Helm chart for deploying Red Hat Developer Hub.
 
-  The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.4/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh
+  The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/telemetry_data_collection/index
 
 dependencies:
   - name: common
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.23.0
+version: 2.24.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,12 +2,12 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square)
+![Version: 2.24.2](https://img.shields.io/badge/Version-2.24.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
 
-The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.4/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh
+The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/telemetry_data_collection/index
 
 **Homepage:** <https://redhat-developer.github.io/rhdh-chart/>
 

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -81,26 +81,46 @@ upstream:
         cpu: 1000m
         memory: 2.5Gi
         ephemeral-storage: 5Gi
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
     readinessProbe:
       failureThreshold: 3
       httpGet:
-        path: /healthcheck
-        port: 7007
+        path: /.backstage/health/v1/readiness
+        port: backend
         scheme: HTTP
-      initialDelaySeconds: 30
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 30
       periodSeconds: 10
       successThreshold: 2
-      timeoutSeconds: 2
+      timeoutSeconds: 4
     livenessProbe:
       failureThreshold: 3
       httpGet:
-        path: /healthcheck
-        port: 7007
+        path: /.backstage/health/v1/liveness
+        port: backend
         scheme: HTTP
-      initialDelaySeconds: 60
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 60
       periodSeconds: 10
       successThreshold: 1
-      timeoutSeconds: 2
+      timeoutSeconds: 4
     extraEnvVars:
       - name: BACKEND_SECRET
         valueFrom:


### PR DESCRIPTION
### What does this PR do?

fix: adjust startup, liveness and readiness probes settings (#50)

* Adjust startup, liveness and readiness probes settings

Startup probe settings seem to have been added in the upstream Backstage Chart
in [1], but the current settings do not allow the RHDH Chart for the
liveness probe to be triggered sufficiently enough for the app to be
considered live.
This adjust such settings by accounting for the worst case scenario
where the application might take a bit long to start.

This also aligns the probe endpoints with the upstream chart.

[1] https://github.com/backstage/charts/pull/216

* Update Chart version

* Update charts/backstage/values.yaml

Co-authored-by: Patrick Knight <pknight@redhat.com>
Co-authored-by: Gustavo Lira e Silva <guga.java@gmail.com>

* Add comment explaining why there is no 'initialDelaySeconds' on both liveness and readiness probes

Co-authored-by: Nick Boldt <nboldt@redhat.com>

---------

Co-authored-by: Patrick Knight <pknight@redhat.com>
Co-authored-by: Gustavo Lira e Silva <guga.java@gmail.com>
Co-authored-by: Nick Boldt <nboldt@redhat.com>

fix URLs and bump to 2.24.2 in 1.4 branch

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.