### PR TITLE
fix: Make the dynamic plugins root PVC storage class configurable [RHDHBUGS-156][RHIDP-5573]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Create KIND Cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
 
+      - name: Create custom storage class
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: storage.k8s.io/v1
+          kind: StorageClass
+          metadata:
+            name: custom-sc
+          # same provisioner as the one used by the default storage class on KinD
+          provisioner: rancher.io/local-path
+          reclaimPolicy: Delete
+          volumeBindingMode: WaitForFirstConsumer
+          EOF
+
       - name: Install Ingress Controller
         run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"
 
@@ -104,6 +117,19 @@ jobs:
 
       - name: Create KIND Cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+
+      - name: Create custom storage class
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: storage.k8s.io/v1
+          kind: StorageClass
+          metadata:
+            name: custom-sc
+          # same provisioner as the one used by the default storage class on KinD
+          provisioner: rancher.io/local-path
+          reclaimPolicy: Delete
+          volumeBindingMode: WaitForFirstConsumer
+          EOF
 
       - name: Install Ingress Controller
         run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.27.0
+version: 2.28.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.27.0](https://img.shields.io/badge/Version-2.27.0-informational?style=flat-square)
+![Version: 2.28.0](https://img.shields.io/badge/Version-2.28.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -141,6 +141,7 @@ Kubernetes: `>= 1.25.0-0`
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
+| dynamicPlugins.cache.volumeClaimSpec | Spec of the dynamic plugins root volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"storageClassName":null}` |
 | global.auth | Enable service authentication within Backstage instance | object | `{"backend":{"enabled":true,"existingSecret":"","value":""}}` |
 | global.auth.backend | Backend service to service authentication <br /> Ref: https://backstage.io/docs/auth/service-to-service-auth/ | object | `{"enabled":true,"existingSecret":"","value":""}` |
 | global.auth.backend.enabled | Enable backend service to service authentication, unless configured otherwise it generates a secret value | bool | `true` |

--- a/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
+++ b/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
@@ -1,0 +1,18 @@
+# Workaround for kind cluster in CI which has no Routes
+route:
+  enabled: false
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        # This custom-sc storage class is created in the test GH Workflow
+        storageClass: custom-sc
+
+dynamicPlugins:
+  cache:
+    volumeClaimSpec:
+      resources:
+        requests:
+          storage: 3Gi
+      # This custom-sc storage class is created in the test GH Workflow
+      storageClassName: custom-sc

--- a/charts/backstage/templates/pvcs.yaml
+++ b/charts/backstage/templates/pvcs.yaml
@@ -3,8 +3,4 @@ apiVersion: v1
 metadata:
   name: {{ printf "%s-dynamic-plugins-root" .Release.Name }}
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
+  {{- toYaml .Values.dynamicPlugins.cache.volumeClaimSpec | nindent 2 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -307,3 +307,15 @@ route:
     # --  Indicates the desired behavior for insecure connections to a route.
     # <br /> While each router may make its own decisions on which ports to expose, this is normally port 80. The only valid values are None, Redirect, or empty for disabled.
     insecureEdgeTerminationPolicy: "Redirect"
+
+dynamicPlugins:
+  cache:
+    # -- Spec of the dynamic plugins root volume claim.
+    # <br/> Note that, by default, this is set to use the default storage class, if available in the cluster.
+    volumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: null

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -253,6 +253,7 @@ upstream:
         enabled: true
         size: 1Gi
         mountPath: /var/lib/pgsql/data
+        storageClass: null
       extraEnvVars:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:


### PR DESCRIPTION
## Description of the change
This PR extracts the dynamic plugins root PVC spec in a new `dynamicPlugins.cache.volumeClaimSpec` field in the values file.

This way, the whole PVC spec is configurable, including the storage class name, along with other things like the PVC size and access modes.

This should also help with https://issues.redhat.com/browse/RHIDP-5516 (make it possible to disable the dynamic plugin cache PVC and switch to an ephemeral volume).

## Existing or Associated Issue(s)

- https://issues.redhat.com/browse/RHDHBUGS-156
- https://issues.redhat.com/browse/RHIDP-5573

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
