### PR TITLE
RHIDP-5654: Adding SNYK IaC Scanning

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,0 +1,38 @@
+name: SNYK
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  scan-iac:
+    name: Scan Rendered Templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
+
+      - name: Render Templates
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add backstage https://backstage.github.io/charts
+          helm repo update    
+          helm dependency build ./charts/backstage
+          helm template ./charts/backstage/ --output-dir ./output
+
+      - name: Run SNYK IaC Scan
+        continue-on-error: true
+        uses: snyk/actions/iac@0.4.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
+        with:
+          args: --report --org=$SNYK_ORG_ID --target-name="redhat-developer/rhdh-chart"
+          file: ./output/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # helm chart dependencies
 charts/*/charts/
 **/charts/*.tgz
+output


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change
Enables SNYK scanning of the rendered Helm templates on a weekly schedule (on Sunday) and then uploads the results to our app.snyk.io account for triaging.
<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)
https://issues.redhat.com/browse/RHIDP-5654
<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
