### PR TITLE
ci: Allow testing PRs targetting release branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           helm repo update
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --helm-extra-args="--set upstream.backstage.image.tag=latest --set global.clusterRouterBase=app.example.yaml"
+        run: ct lint --config ct.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-args="--set upstream.backstage.image.tag=latest --set global.clusterRouterBase=app.example.yaml"
 
       - name: Create KIND Cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run chart-testing (latest)
         # test with latest stable backstage-showcase release
-        run: ct install --config ct-install.yaml --helm-extra-set-args="--set=upstream.backstage.image.tag=latest --set=global.clusterRouterBase=app.example.com"
+        run: ct install --config ct-install.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=latest --set=global.clusterRouterBase=app.example.com"
   test-next:
     name: Test Next Release
     runs-on: ubuntu-latest
@@ -113,7 +113,7 @@ jobs:
           helm repo update
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --helm-extra-args="--set upstream.backstage.image.tag=next --set global.clusterRouterBase=app.example.yaml"
+        run: ct lint --config ct.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-args="--set upstream.backstage.image.tag=next --set global.clusterRouterBase=app.example.yaml"
 
       - name: Create KIND Cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
@@ -136,4 +136,4 @@ jobs:
 
       - name: Run chart-testing (next)
         # test with the next backstage-showcase version (main branch)
-        run: ct install --config ct-install.yaml --helm-extra-set-args="--set=upstream.backstage.image.tag=next --set=global.clusterRouterBase=app.example.com"
+        run: ct install --config ct-install.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=next --set=global.clusterRouterBase=app.example.com"

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,4 +2,3 @@ chart-dirs:
   - charts
 validate-maintainers: false
 remote: origin
-target-branch: main


### PR DESCRIPTION
## Description of the change

PRs (like #80) targetting release branches fail because the linter is configured to detect Chart changes compared to the `main` branch.

## Existing or Associated Issue(s)

https://github.com/redhat-developer/rhdh-chart/actions/runs/13111112811/job/36575072460?pr=80

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
