### PR TITLE
fix(release-1.3): Use the 1.3 RHDH tag by default

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.19.0
+version: 2.19.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -4170,7 +4170,7 @@
                                     "type": "string"
                                 },
                                 "tag": {
-                                    "default": "latest",
+                                    "default": "1.3",
                                     "description": "Immutable tags are recommended.",
                                     "title": "Backstage image tag",
                                     "type": "string"

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -37,7 +37,7 @@ upstream:
     image:
       registry: quay.io
       repository: rhdh/rhdh-hub-rhel9
-      tag: latest
+      tag: "1.3"
     command: []
     # FIXME (tumido): USE POSTGRES_PASSWORD and POSTGRES_USER instead of POSTGRES_ADMIN_PASSWORD
     # This is a hack. In {fedora,rhel}/postgresql images, regular user is forbidden


### PR DESCRIPTION
## Description of the change

'latest' might point to a newer RHDH image, which may not be compatible with the current Chart.

We can use `latest` in the main branch, but release branches should be using a specific tag.

## Existing or Associated Issue(s)

CI issues like https://github.com/redhat-developer/rhdh-chart/actions/runs/13111723456/job/36576912437?pr=80

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
