### PR TITLE
fix: Fix missing `auth.providers` config causing app startup to fail in `release-1.3`

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.19.0
+version: 2.19.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -954,6 +954,9 @@
                                 "app": {
                                     "baseUrl": "https://{{- include \"janus-idp.hostname\" . }}"
                                 },
+                                "auth": {
+                                    "providers": {}
+                                },
                                 "backend": {
                                     "auth": {
                                         "externalAccess": [

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -47,6 +47,8 @@ upstream:
     # create multiple DBs. Since Backstage requires by default 5 different DBs, we
     # can't accommodate that properly.
     appConfig:
+      auth:
+        providers: {}
       app:
         # Please update to match host in case you don't want to configure hostname via `global.clusterRouterBase` or `global.host` if not deploying on an openshift cluster.
         baseUrl: 'https://{{- include "janus-idp.hostname" . }}'


### PR DESCRIPTION
## Description of the change

Fix missing `auth.providers` config causing app startup to fail in `release-1.3`

## Existing or Associated Issue(s)

- Fixes issues seen in https://github.com/redhat-developer/rhdh-chart/actions/runs/13112079983/job/36578033682?pr=86 and https://github.com/redhat-developer/rhdh-chart/actions/runs/13111723456/job/36576912437?pr=80 while trying to backport a few fixes to 1.3
- Related to https://github.com/redhat-developer/rhdh-chart/pull/46

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
