### PR TITLE
fix(release-1.3): Make the audit log PVC configurable [RHIDP-5839]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.19.3
+version: 2.19.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.19.3](https://img.shields.io/badge/Version-2.19.3-informational?style=flat-square)
+![Version: 2.19.4](https://img.shields.io/badge/Version-2.19.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -181,6 +181,7 @@ Kubernetes: `>= 1.25.0-0`
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
+| auditLog.volumeClaimSpec | Spec of the audit log volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":null}` |
 | dynamicPlugins.cache.volumeClaimSpec | Spec of the dynamic plugins root volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"storageClassName":null}` |
 | global.auth | Enable service authentication within Backstage instance | object | `{"backend":{"enabled":true,"existingSecret":"","value":""}}` |
 | global.auth.backend | Backend service to service authentication <br /> Ref: https://backstage.io/docs/auth/service-to-service-auth/ | object | `{"enabled":true,"existingSecret":"","value":""}` |

--- a/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
+++ b/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
@@ -8,6 +8,14 @@ upstream:
         # This custom-sc storage class is created in the test GH Workflow
         storageClass: custom-sc
 
+auditLog:
+  volumeClaimSpec:
+    resources:
+      requests:
+        storage: 2Gi
+    # This custom-sc storage class is created in the test GH Workflow
+    storageClassName: custom-sc
+
 dynamicPlugins:
   cache:
     volumeClaimSpec:

--- a/charts/backstage/templates/pvcs.yaml
+++ b/charts/backstage/templates/pvcs.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ printf "%s-audit-log" .Release.Name }}
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
+  {{- toYaml .Values.auditLog.volumeClaimSpec | nindent 2 }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -285,6 +285,17 @@ route:
     # <br /> While each router may make its own decisions on which ports to expose, this is normally port 80. The only valid values are None, Redirect, or empty for disabled.
     insecureEdgeTerminationPolicy: "Redirect"
 
+auditLog:
+  # -- Spec of the audit log volume claim.
+  # <br/> Note that, by default, this is set to use the default storage class, if available in the cluster.
+  volumeClaimSpec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+    storageClassName: null
+
 dynamicPlugins:
   cache:
     # -- Spec of the dynamic plugins root volume claim.


### PR DESCRIPTION
## Description of the change

This makes the audit log PVC in 1.3 configurable, for the same reasons related to the dynamic plugins root PVC, as depicted in https://issues.redhat.com/browse/RHDHBUGS-135 (Helm upgrade failures) and https://issues.redhat.com/browse/RHIDP-5342 (cannot run 2 replicas).

Note that this fix is only for 1.3, as the audit log PVC has been removed in 1.4 (see https://github.com/redhat-developer/rhdh-chart/pull/47 - https://issues.redhat.com/browse/RHIDP-4852)

## Existing or Associated Issue(s)

- Fixes https://issues.redhat.com/browse/RHIDP-5839
- Related to https://issues.redhat.com/browse/RHDHBUGS-135

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
