### PR TITLE
fix(release-1.4): Fix hardcoded image for test connection pod and allow to skip the creation of this pod [RHDHBUGS-155] [RHIDP-5558]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.24.3
+version: 2.24.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.24.3](https://img.shields.io/badge/Version-2.24.3-informational?style=flat-square)
+![Version: 2.24.4](https://img.shields.io/badge/Version-2.24.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -118,6 +118,46 @@ helm upgrade -i <release_name> oci://ghcr.io/redhat-developer/rhdh-chart/backsta
 
 > **Tip**: List all releases using `helm list`
 
+### Testing a Release
+
+Once an Helm Release has been deployed, you can test it using the [`helm test`](https://helm.sh/docs/helm/helm_test/) command:
+
+```sh
+helm test <release_name>
+```
+
+This will run a simple Pod in the cluster to check that the application deployed is up and running.
+
+You can control whether to disable this test pod or you can also customize the image it leverages.
+See the `test.enabled` and `test.image` parameters in the [`values.yaml`](./values.yaml) file.
+
+> **Tip**: Disabling the test pod will not prevent the `helm test` command from passing later on. It will simply report that no test suite is available.
+
+Below are a few examples:
+
+<details>
+
+<summary>Disabling the test pod</summary>
+
+```sh
+helm install <release_name> <repo_or_oci_registry> \
+  --set test.enabled=false
+```
+
+</details>
+
+<details>
+
+<summary>Customizing the test pod image</summary>
+
+```sh
+helm install <release_name> <repo_or_oci_registry> \
+  --set test.image.repository=curl/curl-base \
+  --set test.image.tag=8.11.1
+```
+
+</details>
+
 ### Uninstalling the Chart
 
 To uninstall/delete the `my-backstage-release` deployment:
@@ -166,6 +206,11 @@ Kubernetes: `>= 1.25.0-0`
 | route.tls.key | Key file contents | string | `""` |
 | route.tls.termination | Specify TLS termination. | string | `"edge"` |
 | route.wildcardPolicy | Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed. | string | `"None"` |
+| test | Test pod parameters | object | `{"enabled":true,"image":{"registry":"quay.io","repository":"curl/curl","tag":"latest"}}` |
+| test.enabled | Whether to enable the test-connection pod used for testing the Release using `helm test`. | bool | `true` |
+| test.image.registry | Test connection pod image registry | string | `"quay.io"` |
+| test.image.repository | Test connection pod image repository. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"curl/curl"` |
+| test.image.tag | Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"latest"` |
 | upstream | Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml) | object | Use Openshift compatible settings |
 | upstream.backstage.initContainers[0].image | Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount. It could be replaced by a custom image based on this one. | string | `quay.io/janus-idp/backstage-showcase:latest` |
 

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -110,6 +110,46 @@ helm upgrade -i <release_name> oci://ghcr.io/redhat-developer/rhdh-chart/backsta
 
 > **Tip**: List all releases using `helm list`
 
+### Testing a Release
+
+Once an Helm Release has been deployed, you can test it using the [`helm test`](https://helm.sh/docs/helm/helm_test/) command:
+
+```sh
+helm test <release_name>
+```
+
+This will run a simple Pod in the cluster to check that the application deployed is up and running.
+
+You can control whether to disable this test pod or you can also customize the image it leverages.
+See the `test.enabled` and `test.image` parameters in the [`values.yaml`](./values.yaml) file.
+
+> **Tip**: Disabling the test pod will not prevent the `helm test` command from passing later on. It will simply report that no test suite is available.
+
+Below are a few examples:
+
+<details>
+
+<summary>Disabling the test pod</summary>
+
+```sh
+helm install <release_name> <repo_or_oci_registry> \
+  --set test.enabled=false
+```
+
+</details>
+
+<details>
+
+<summary>Customizing the test pod image</summary>
+
+```sh
+helm install <release_name> <repo_or_oci_registry> \
+  --set test.image.repository=curl/curl-base \
+  --set test.image.tag=8.11.1
+```
+
+</details>
+
 ### Uninstalling the Chart
 
 To uninstall/delete the `my-backstage-release` deployment:

--- a/charts/backstage/ci/with-custom-image-for-test-pod-values.yaml
+++ b/charts/backstage/ci/with-custom-image-for-test-pod-values.yaml
@@ -1,0 +1,14 @@
+# Workaround for kind cluster in CI which has no Routes and no PVCs
+route:
+  enabled: false
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+test:
+  image:
+    registry: quay.io
+    repository: curl/curl-base
+    tag: 8.11.1

--- a/charts/backstage/ci/with-test-pod-disabled-values.yaml
+++ b/charts/backstage/ci/with-test-pod-disabled-values.yaml
@@ -1,0 +1,11 @@
+# Workaround for kind cluster in CI which has no Routes and no PVCs
+route:
+  enabled: false
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+test:
+  enabled: false

--- a/charts/backstage/templates/tests/test-connection.yaml
+++ b/charts/backstage/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -8,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-      helm.sh/hook: test
+    helm.sh/hook: test
 spec:
   containers:
     - name: curl
@@ -30,10 +31,11 @@ spec:
           command:
           - ls
           - /usr/bin/curl
-      image: quay.io/curl/curl:latest
+      image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh", "-c"]
       args:
         - |
           curl --connect-timeout 5 --max-time 20 --retry 20 --retry-delay 10 --retry-max-time 60 --retry-all-errors {{ include "common.names.fullname" . }}:{{ .Values.upstream.service.ports.backend }}
   restartPolicy: Never
+{{- end }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -320,3 +320,18 @@ dynamicPlugins:
         requests:
           storage: 5Gi
       storageClassName: null
+
+# -- Test pod parameters
+test:
+  # -- Whether to enable the test-connection pod used for testing the Release using `helm test`.
+  enabled: true
+
+  image:
+    # -- Test connection pod image registry
+    registry: quay.io
+
+    # -- Test connection pod image repository. Note that the image needs to have both the `sh` and `curl` binaries in it.
+    repository: curl/curl
+
+    # -- Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it.
+    tag: latest


### PR DESCRIPTION
## Description of the change

Cherry-pick of #54

## Existing or Associated Issue(s)

- Fixes https://issues.redhat.com/browse/RHIDP-5838

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
