### PR TITLE
fix: Revert setting storage class fields to `null` by default [RHIDP-5953]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run chart-testing (latest)
         # test with latest stable backstage-showcase release
-        run: ct install --config ct-install.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=latest --set=global.clusterRouterBase=app.example.com"
+        run: ct install --config ct-install.yaml --upgrade --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=latest --set=global.clusterRouterBase=app.example.com"
   test-next:
     name: Test Next Release
     runs-on: ubuntu-latest
@@ -136,4 +136,4 @@ jobs:
 
       - name: Run chart-testing (next)
         # test with the next backstage-showcase version (main branch)
-        run: ct install --config ct-install.yaml --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=next --set=global.clusterRouterBase=app.example.com"
+        run: ct install --config ct-install.yaml --upgrade --target-branch ${{ github.event.pull_request.base.ref }} --helm-extra-set-args="--set=upstream.backstage.image.tag=next --set=global.clusterRouterBase=app.example.com"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.2
+version: 3.0.3

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -268,7 +268,6 @@ upstream:
         enabled: true
         size: 1Gi
         mountPath: /var/lib/pgsql/data
-        storageClass: null
       extraEnvVars:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:


### PR DESCRIPTION
## Description of the change

When the DB PVC is initially created, it gets assigned the default storage class.

And it becomes impossible to upgrade the Helm Release later on because it looks like the (immutable) PVC is being patched after creation

## Existing or Associated Issue(s)

Relates to https://issues.redhat.com/browse/RHIDP-5953

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
