### PR TITLE
fix(release-1.3): Revert setting storage class fields to `null` by default [RHIDP-5952]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.19.4
+version: 2.19.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 2.19.4](https://img.shields.io/badge/Version-2.19.4-informational?style=flat-square)
+![Version: 2.19.5](https://img.shields.io/badge/Version-2.19.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -181,8 +181,8 @@ Kubernetes: `>= 1.25.0-0`
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
-| auditLog.volumeClaimSpec | Spec of the audit log volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":null}` |
-| dynamicPlugins.cache.volumeClaimSpec | Spec of the dynamic plugins root volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"storageClassName":null}` |
+| auditLog.volumeClaimSpec | Spec of the audit log volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}}}` |
+| dynamicPlugins.cache.volumeClaimSpec | Spec of the dynamic plugins root volume claim. <br/> Note that, by default, this is set to use the default storage class, if available in the cluster. | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}}}` |
 | global.auth | Enable service authentication within Backstage instance | object | `{"backend":{"enabled":true,"existingSecret":"","value":""}}` |
 | global.auth.backend | Backend service to service authentication <br /> Ref: https://backstage.io/docs/auth/service-to-service-auth/ | object | `{"enabled":true,"existingSecret":"","value":""}` |
 | global.auth.backend.enabled | Enable backend service to service authentication, unless configured otherwise it generates a secret value | bool | `true` |

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -232,7 +232,6 @@ upstream:
         enabled: true
         size: 1Gi
         mountPath: /var/lib/pgsql/data
-        storageClass: null
       extraEnvVars:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:
@@ -294,7 +293,6 @@ auditLog:
     resources:
       requests:
         storage: 1Gi
-    storageClassName: null
 
 dynamicPlugins:
   cache:
@@ -306,7 +304,6 @@ dynamicPlugins:
       resources:
         requests:
           storage: 5Gi
-      storageClassName: null
 
 # -- Test pod parameters
 test:


### PR DESCRIPTION
## Description of the change

When the dynamic plugins root, audit log and DB PVCs are initially created, they get assigned the default storage class.

And it becomes impossible to upgrade the Helm Release later on because it looks like these (immutable) PVCs are being patched after creation.

See the repro steps in the JIRA issue below.

## Existing or Associated Issue(s)

Fixes https://issues.redhat.com/browse/RHIDP-5952

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
