### PR TITLE
chore: Fix the support URLs pointing to disabled GH issues

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -3,14 +3,14 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: support
-      url: https://github.com/redhat-developer/rhdh-chart/issues
+      url: https://issues.redhat.com/browse/RHIDP
     - name: Chart Source
       url: https://github.com/redhat-developer/rhdh-chart
     - name: Default Image Source
       url: https://github.com/janus-idp/backstage-showcase
   charts.openshift.io/name: Backstage
   charts.openshift.io/provider: Red Hat Developer Hub Team
-  charts.openshift.io/supportURL: https://github.com/redhat-developer/rhdh-chart/issues
+  charts.openshift.io/supportURL: https://issues.redhat.com/browse/RHIDP
 apiVersion: v2
 description: |
   A Helm chart for deploying Red Hat Developer Hub.
@@ -44,4 +44,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

GH Issues are disabled on this repo, but the support URLs metadata were mentioning it. THis fixes that, by pointing to JIRA instead.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

&mdash;

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
