### PR TITLE
ci: Disable fail-fast strategy for the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
 
   test-chart:
     strategy:
+      fail-fast: false
       matrix:
         version:
           # 'latest' is the latest RC or stable release of RHDH (built from a release branch)


### PR DESCRIPTION
## Description of the change

This PR disables the [fail-fast](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures) behavior on the CI test matrix, which is enabled by default.
Otherwise, if one job in the matrix fails, all other jobs that are still running will be cancelled.
It would be interesting IMO to get results from all matrix jobs (testing different versions of RHDH), regardless of individual failures.

## Existing or Associated Issue(s)

&mdash;

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
