### PR TITLE
fix(orchestrator-infra): Add missing `README.md.gotmpl` file to fix the pre-commit hooks  [RHIDP-6650]

### DIFF
--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.0.1
+version: 0.0.2

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,8 @@
 
-# orchestrator-infra
+# Orchestrator Infra Chart for OpenShift (Community Version)
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Logic Operator and OpenShift Serverless Operator.
 
@@ -19,25 +20,84 @@ Helm chart to deploy the Orchestrator solution's required infrastructure suite o
 
 Kubernetes: `>= 1.25.0-0`
 
+## TL;DR
+
+```console
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install my-orchestrator-infra redhat-developer/orchestrator-infra
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Testing a Release
+
+Once an Helm Release has been deployed, you can test it using the [`helm test`](https://helm.sh/docs/helm/helm_test/) command:
+
+```sh
+helm test <release_name>
+```
+
+This will run a simple Pod in the cluster to check that the required resources have been created.
+
+You can control whether to disable this test pod or you can also customize the image it leverages.
+See the `test.enabled` and `test.image` parameters in the [`values.yaml`](./values.yaml) file.
+
+> **Tip**: Disabling the test pod will not prevent the `helm test` command from passing later on. It will simply report that no test suite is available.
+
+Below are a few examples:
+
+<details>
+
+<summary>Disabling the test pod</summary>
+
+```sh
+helm install <release_name> <repo> \
+  --set test.enabled=false
+```
+
+</details>
+
+<details>
+
+<summary>Customizing the test pod image</summary>
+
+```sh
+helm install <release_name> <repo> \
+  --set test.image=<image>
+```
+
+</details>
+
+## Uninstalling the Chart
+
+To uninstall/delete a `my-backstage-release` deployment:
+
+```console
+helm uninstall my-backstage-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
 ## Values
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
-| serverlessLogicOperator.enabled |  | bool | `true` |
-| serverlessLogicOperator.subscription.namespace |  | string | `"openshift-serverless-logic"` |
-| serverlessLogicOperator.subscription.spec.channel |  | string | `"alpha"` |
-| serverlessLogicOperator.subscription.spec.installPlanApproval |  | string | `"Manual"` |
-| serverlessLogicOperator.subscription.spec.name |  | string | `"logic-operator-rhel8"` |
-| serverlessLogicOperator.subscription.spec.source |  | string | `"redhat-operators"` |
+| serverlessLogicOperator.enabled | whether the operator should be deployed by the chart | bool | `true` |
+| serverlessLogicOperator.subscription.namespace | namespace where the operator should be deployed | string | `"openshift-serverless-logic"` |
+| serverlessLogicOperator.subscription.spec.channel | channel of an operator package to subscribe to | string | `"alpha"` |
+| serverlessLogicOperator.subscription.spec.installPlanApproval | whether the update should be installed automatically | string | `"Manual"` |
+| serverlessLogicOperator.subscription.spec.name | name of the operator package | string | `"logic-operator-rhel8"` |
+| serverlessLogicOperator.subscription.spec.source | name of the catalog source | string | `"redhat-operators"` |
 | serverlessLogicOperator.subscription.spec.sourceNamespace |  | string | `"openshift-marketplace"` |
-| serverlessLogicOperator.subscription.spec.startingCSV |  | string | `"logic-operator-rhel8.v1.35.0"` |
-| serverlessOperator.enabled |  | bool | `true` |
-| serverlessOperator.subscription.namespace |  | string | `"openshift-serverless"` |
-| serverlessOperator.subscription.spec.channel |  | string | `"stable"` |
-| serverlessOperator.subscription.spec.installPlanApproval |  | string | `"Manual"` |
-| serverlessOperator.subscription.spec.name |  | string | `"serverless-operator"` |
-| serverlessOperator.subscription.spec.source |  | string | `"redhat-operators"` |
+| serverlessLogicOperator.subscription.spec.startingCSV | The initial version of the operator | string | `"logic-operator-rhel8.v1.35.0"` |
+| serverlessOperator.enabled | whether the operator should be deployed by the chart | bool | `true` |
+| serverlessOperator.subscription.namespace | namespace where the operator should be deployed | string | `"openshift-serverless"` |
+| serverlessOperator.subscription.spec.channel | channel of an operator package to subscribe to | string | `"stable"` |
+| serverlessOperator.subscription.spec.installPlanApproval | whether the update should be installed automatically | string | `"Manual"` |
+| serverlessOperator.subscription.spec.name | name of the operator package | string | `"serverless-operator"` |
+| serverlessOperator.subscription.spec.source | name of the catalog source | string | `"redhat-operators"` |
 | serverlessOperator.subscription.spec.sourceNamespace |  | string | `"openshift-marketplace"` |
-| tests.enabled |  | bool | `true` |
-| tests.image |  | string | `"bitnami/kubectl:latest"` |
+| tests.enabled | Whether to create the test pod used for testing the Release using `helm test`. | bool | `true` |
+| tests.image | Test pod image | string | `"bitnami/kubectl:latest"` |
 

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -71,10 +71,10 @@ helm install <release_name> <repo> \
 
 ## Uninstalling the Chart
 
-To uninstall/delete a `my-backstage-release` deployment:
+To uninstall/delete a Helm release named `my-orchestrator-infra`:
 
 ```console
-helm uninstall my-backstage-release
+helm uninstall my-orchestrator-infra
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -1,0 +1,77 @@
+# Orchestrator Infra Chart for OpenShift (Community Version)
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}
+{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## TL;DR
+
+```console
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install my-orchestrator-infra redhat-developer/orchestrator-infra
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Testing a Release
+
+Once an Helm Release has been deployed, you can test it using the [`helm test`](https://helm.sh/docs/helm/helm_test/) command:
+
+```sh
+helm test <release_name>
+```
+
+This will run a simple Pod in the cluster to check that the required resources have been created.
+
+You can control whether to disable this test pod or you can also customize the image it leverages.
+See the `test.enabled` and `test.image` parameters in the [`values.yaml`](./values.yaml) file.
+
+> **Tip**: Disabling the test pod will not prevent the `helm test` command from passing later on. It will simply report that no test suite is available.
+
+Below are a few examples:
+
+<details>
+
+<summary>Disabling the test pod</summary>
+
+```sh
+helm install <release_name> <repo> \
+  --set test.enabled=false
+```
+
+</details>
+
+<details>
+
+<summary>Customizing the test pod image</summary>
+
+```sh
+helm install <release_name> <repo> \
+  --set test.image=<image>
+```
+
+</details>
+
+## Uninstalling the Chart
+
+To uninstall/delete a `my-backstage-release` deployment:
+
+```console
+helm uninstall my-backstage-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -66,10 +66,10 @@ helm install <release_name> <repo> \
 
 ## Uninstalling the Chart
 
-To uninstall/delete a `my-backstage-release` deployment:
+To uninstall/delete a Helm release named `my-orchestrator-infra`:
 
 ```console
-helm uninstall my-backstage-release
+helm uninstall my-orchestrator-infra
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/charts/orchestrator-infra/ci/upstream-olm-values.yaml
+++ b/charts/orchestrator-infra/ci/upstream-olm-values.yaml
@@ -1,0 +1,12 @@
+serverlessLogicOperator:
+  enabled: true
+  subscription:
+    namespace: operators
+    spec:
+      sourceNamespace: olm
+
+serverlessOperator:
+  subscription:
+    namespace: operators
+    spec:
+      sourceNamespace: olm

--- a/charts/orchestrator-infra/values.yaml
+++ b/charts/orchestrator-infra/values.yaml
@@ -1,26 +1,42 @@
 serverlessLogicOperator:
-  enabled: true  # whether the operator should be deployed by the chart
+  # -- whether the operator should be deployed by the chart
+  enabled: true
   subscription:
-    namespace: openshift-serverless-logic  #  namespace where the operator should be deployed
+    # -- namespace where the operator should be deployed
+    namespace: openshift-serverless-logic
     spec:
-      channel: alpha  #  channel of an operator package to subscribe to
-      installPlanApproval: Manual  #  whether the update should be installed automatically
-      name: logic-operator-rhel8  #  name of the operator package
-      source: redhat-operators  #  name of the catalog source
+      # -- channel of an operator package to subscribe to
+      channel: alpha
+      # --  whether the update should be installed automatically
+      installPlanApproval: Manual
+      # -- name of the operator package
+      name: logic-operator-rhel8
+      # --  name of the catalog source
+      source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: logic-operator-rhel8.v1.35.0  # The initial version of the operator
+      # -- The initial version of the operator
+      startingCSV: logic-operator-rhel8.v1.35.0
 
 serverlessOperator:
-  enabled: true  #  whether the operator should be deployed by the chart
+  # -- whether the operator should be deployed by the chart
+  enabled: true
   subscription:
-    namespace: openshift-serverless  # namespace where the operator should be deployed
+    # -- namespace where the operator should be deployed
+    namespace: openshift-serverless
     spec:
-      channel: stable  #  channel of an operator package to subscribe to
-      installPlanApproval: Manual  #  whether the update should be installed automatically
-      name: serverless-operator  #  name of the operator package
-      source: redhat-operators  #  name of the catalog source
+      # -- channel of an operator package to subscribe to
+      channel: stable
+      # -- whether the update should be installed automatically
+      installPlanApproval: Manual
+      # -- name of the operator package
+      name: serverless-operator
+      # -- name of the catalog source
+      source: redhat-operators
       sourceNamespace: openshift-marketplace
 
+# -- Test pod parameters
 tests:
+  # -- Whether to create the test pod used for testing the Release using `helm test`.
   enabled: true
+  # -- Test pod image
   image: bitnami/kubectl:latest

--- a/charts/orchestrator-infra/values.yaml
+++ b/charts/orchestrator-infra/values.yaml
@@ -34,7 +34,6 @@ serverlessOperator:
       source: redhat-operators
       sourceNamespace: openshift-marketplace
 
-# -- Test pod parameters
 tests:
   # -- Whether to create the test pod used for testing the Release using `helm test`.
   enabled: true


### PR DESCRIPTION
## Description of the change

As reported  in https://github.com/redhat-developer/rhdh-chart/pull/102, when the pre-commit hooks run against the repo, they automatically end up updating the `charts/orchestrator-infra/README.md` file.

@coreydaley pointed out that `helm-docs` would use a default README template if there is none in the Chart folder.

This PR adds a custom README.md.gotmpl similar to the `charts/backstage` one: https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/README.md.gotmpl

It also makes sure that the field comments in the values.yaml are consistent, so that `helm-docs` can detect and add them to the generated README.md file.

## Existing or Associated Issue(s)

https://issues.redhat.com/browse/RHIDP-6650

## Additional Information

This is an example of how the generated README.md file looks like: https://github.com/rm3l/rhdh-chart/blob/ae1b07e59d48353df60d0feee68a3946f081fedb/charts/orchestrator-infra/README.md

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
