### PR TITLE
ci: Skip running some expensive steps (like cluster creation) if there are no changed charts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,16 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
-      - name: Lint charts
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch "${{ github.event.pull_request.base.ref }}")
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct lint \
             --debug \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,16 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch "${{ github.event.pull_request.base.ref }}")
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Add NGINX Ingress and Bitnami Repository"
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add ingress-nginx "https://kubernetes.github.io/ingress-nginx"
           helm repo add bitnami "https://charts.bitnami.com/bitnami"
@@ -59,6 +68,7 @@ jobs:
           helm repo update
 
       - name: Generate KinD Config
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           cat <<EOF > /tmp/kind-config.yaml
           apiVersion: kind.x-k8s.io/v1alpha4
@@ -75,11 +85,13 @@ jobs:
           EOF
 
       - name: Create KIND Cluster
+        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           config: /tmp/kind-config.yaml
 
       - name: Create custom storage class
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           export defaultScProvisioner=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].provisioner}')
           if [[ -z "$defaultScProvisioner" ]]; then
@@ -102,12 +114,14 @@ jobs:
           kubectl get storageclass custom-sc -o yaml
 
       - name: Install Ingress Controller
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm install ingress-nginx/ingress-nginx --generate-name \
             --set controller.service.type='NodePort' \
             --set controller.admissionWebhooks.enabled=false
 
       - name: Install Operator Lifecycle Manager (OLM)
+        if: steps.list-changed.outputs.changed == 'true'
         # In case we need to install additional Operators
         env:
           OLM_VERSION: "v0.31.0"
@@ -116,7 +130,8 @@ jobs:
           chmod +x install-olm.sh
           ./install-olm.sh "${OLM_VERSION}"
 
-      - name: Run chart-testing
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install \
             --debug \

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.0.3
+version: 0.0.4

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.0.4
+version: 0.0.3


### PR DESCRIPTION
## Description of the change

If no chart has changed, it doesn't make sense to create a cluster then install OLM, so that `ct lint` and `ct install` would report that nothing has changed.
This PR speeds things up in such case by skipping these useless (but expensive) steps.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
