### PR TITLE
ci: Add missing Helm repos for the lint job to pass

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,6 +46,13 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Add Helm Repositories
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add backstage https://backstage.github.io/charts
+          helm repo update
+
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,11 +59,11 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: "Add NGINX Ingress and Bitnami Repository"
+      - name: Add Helm Repositories
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm repo add ingress-nginx "https://kubernetes.github.io/ingress-nginx"
-          helm repo add bitnami "https://charts.bitnami.com/bitnami"
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add backstage https://backstage.github.io/charts
           helm repo update
 


### PR DESCRIPTION
## Description of the change

This adds the missing Helm repos before running `ct lint`. This causes the lint failure observed in #127

## Existing or Associated Issue(s)

Fixes https://github.com/redhat-developer/rhdh-chart/actions/runs/14398222155/job/40380952944#step:7:32

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
