### PR TITLE
chore(chart): fix Orchestrator Infra Chart metadata to avoid conflicts with RHDH Chart

### DIFF
--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -1,11 +1,12 @@
 annotations:
-  charts.openshift.io/name: Orchestrator-Infra
+  charts.openshift.io/name: Orchestrator Infrastructure for Red Hat Developer Hub (CI Build)
   charts.openshift.io/provider: Red Hat Developer Hub Team
   charts.openshift.io/supportURL: https://issues.redhat.com/browse/RHIDP
 apiVersion: v2
-name: orchestrator-infra
+name: redhat-developer-hub-orchestrator-infra
 description: >
-  Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Logic Operator and OpenShift Serverless Operator.
+  Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including
+  OpenShift Serverless Operator and OpenShift Serverless Logic Operator, used by the RHDH Orchestrator flavor.
 kubeVersion: ">= 1.25.0-0"
 maintainers:
   - name: Red Hat Developer Hub Team

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.0.3
+version: 0.0.4

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: redhat-developer-hub-orchestrator-infra
 description: >
   Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including
-  OpenShift Serverless Operator and OpenShift Serverless Logic Operator, used by the RHDH Orchestrator flavor.
+  OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
 kubeVersion: ">= 1.25.0-0"
 maintainers:
   - name: Red Hat Developer Hub Team

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -1,5 +1,5 @@
 annotations:
-  charts.openshift.io/name: Orchestrator Infrastructure for Red Hat Developer Hub (CI Build)
+  charts.openshift.io/name: Orchestrator Infrastructure for Red Hat Developer Hub
   charts.openshift.io/provider: Red Hat Developer Hub Team
   charts.openshift.io/supportURL: https://issues.redhat.com/browse/RHIDP
 apiVersion: v2

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift (Community Version)
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, used by the RHDH Orchestrator flavor.

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -4,7 +4,7 @@
 ![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, used by the RHDH Orchestrator flavor.
+Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
 
 ## Maintainers
 

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -4,7 +4,7 @@
 ![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Logic Operator and OpenShift Serverless Operator.
+Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, used by the RHDH Orchestrator flavor.
 
 ## Maintainers
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change
This PR updates the Chart.yaml metadata for the orchestrator-infra chart to avoid conflicts with the main Red Hat Developer Hub (RHDH) chart in Quay and Helm search results.

Why this change is needed: The original metadata reused several fields (e.g. name, charts.openshift.io/name, description) from the RHDH chart, which caused ambiguity and potential collisions when both charts were published as OCI artifacts.
<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->
Related issue: https://issues.redhat.com/browse/RHIDP-6169
## Additional Information
For example, the orchestrator-infra-chart artifact in quay:
```bash
annotations:
  charts.openshift.io/archs: x86_64
  charts.openshift.io/name: Red Hat Developer Hub (CI Build)
  charts.openshift.io/provider: Red Hat
  charts.openshift.io/supportURL: https://access.redhat.com/support
apiVersion: v2
appVersion: 1.6.0
description: A Helm chart for deploying Red Hat Developer Hub (CI Build)
home: https://red.ht/rhdh
icon:  ...
keywords:
- backstage
- idp
- janus-idp
- developer-hub
- redhat-developer-hub
- redhat
kubeVersion: '>= 1.19.0-0'
maintainers:
- name: Red Hat
  url: https://redhat.com/
name: orchestrator-infra-chart
type: application
version: 1.6.0-CI
``` 
Hence, the Chart metadata needing to be updated. Otherwise, it might conflict with the metadata of the RHDH Chart. In particular [charts.openshift.io/name](http://charts.openshift.io/name)  something like Orchestrator Infrastructure for Red Hat Developer Hub (CI Build) would make better sense and distinguish it from the RHDH chart and description  should be the same as https://github.com/redhat-developer/rhdh-chart/blob/main/charts/orchestrator-infra/Chart.yaml#L7-L8 name ideally something like redhat-developer-hub-orchestrator-infra
 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
