### PR TITLE
chore: enable Snyk scan for orchestrator-infra chart

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -29,7 +29,7 @@ jobs:
           helm template ./charts/backstage --output-dir ./output/backstage
           helm template ./charts/orchestrator-infra --output-dir ./output/orchestrator-infra
 
-      - name: Run SNYK IaC Scan for Backstage
+      - name: Run SNYK IaC Scan for Developer Hub
         continue-on-error: true
         uses: snyk/actions/iac@0.4.0
         env:

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run SNYK IaC Scan for Developer Hub
         continue-on-error: true
-        uses: snyk/actions/iac@0.4.0
+        uses: snyk/actions/iac@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run Snyk IaC Scan for Orchestrator Infra
         continue-on-error: true
-        uses: snyk/actions/iac@0.4.0
+        uses: snyk/actions/iac@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -25,14 +25,26 @@ jobs:
           helm repo add backstage https://backstage.github.io/charts
           helm repo update    
           helm dependency build ./charts/backstage
-          helm template ./charts/backstage/ --output-dir ./output
+          helm dependency build ./charts/orchestrator-infra
+          helm template ./charts/backstage --output-dir ./output/backstage
+          helm template ./charts/orchestrator-infra --output-dir ./output/orchestrator-infra
 
-      - name: Run SNYK IaC Scan
+      - name: Run SNYK IaC Scan for Backstage
         continue-on-error: true
-        uses: snyk/actions/iac@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
+        uses: snyk/actions/iac@0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
         with:
-          args: --report --org=$SNYK_ORG_ID --target-name="redhat-developer/rhdh-chart"
-          file: ./output/
+          args: --report --org=$SNYK_ORG_ID --target-name="redhat-developer/rhdh-chart/backstage"
+          file: ./output/backstage
+
+      - name: Run Snyk IaC Scan for Orchestrator Infra
+        continue-on-error: true
+        uses: snyk/actions/iac@0.4.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
+        with:
+          args: --report --org=$SNYK_ORG_ID --target-name="redhat-developer/rhdh-chart/orchestrator-infra"
+          file: ./output/orchestrator-infra


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change
This PR updates the snyk.yaml GitHub Actions workflow to include IaC scanning of the orchestrator-infra Helm chart in addition to the existing backstage chart.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)
https://issues.redhat.com/browse/RHIDP-6630 

<!-- List any related issues. -->

## Additional Information
Added helm dependency build and helm template for charts/orchestrator-infra.
Added a separate Snyk IaC scan step targeting the rendered output of orchestrator-infra.
Ensures both backstage and orchestrator-infra templates are scanned weekly for infrastructure vulnerabilities.



 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
