### PR TITLE
Added documentation for MAX_ENTRY_SIZE override

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -348,6 +348,33 @@ helm install <release_name> charts/orchestrator-infra
 3. Install backstage chart with helm, setting orchestrator to be enabled.
 4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
 
+### Additional value configurations
+
+To install orchestrator, you must edit the values.yaml to include the follwing MAX_ENTRY_SIZE enviroment variable in the install-dynamic-plugins init container:
+```env:
+  - name: NPM_CONFIG_USERCONFIG
+    value: /opt/app-root/src/.npmrc.dynamic-plugins
+  - name: MAX_ENTRY_SIZE
+    value: '30000000'
+```
+You can do this by editing and overriding the base values.yaml for the backstage chart, which can be found [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml)
+
+### Enablement of Notifications Plugin
+To enable the notifications and signals plugin, please edit the dynamic plugin configmap post-installation and add the following:
+```     
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+Enabling these plugins will allow to recieve notifications from workflows running with Orchestrator.
+
+### Using Orchestrator while configuring an ExternalDB
+
 To use orchestrator with an external DB, please follow the instructions in [our documentation](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)
 and populate the following values in the values.yaml:
 ```bash
@@ -356,8 +383,11 @@ and populate the following values in the values.yaml:
 ```
 Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
 
+To avoid setting varialbles inline in the helm command, you can prepeare an alternatve values file, like <orchestrator-overriding-values.yaml> that will encapsulate all value changes that are required smoothly install Orchestrator via the backstage helm chart.
+The default values.yaml can be found [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml)
 Finally, install the helm chart:
+
 ```
-helm install <release_name> charts/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
---set externalDBsecretRef=<cred-secret> --set externalDBName=example
+helm install <release_name> backstage/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
+--set externalDBsecretRef=<cred-secret> --set externalDBName=example --values=<orchestrator-overriding-values.yaml>
 ```

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -283,6 +283,33 @@ helm install <release_name> charts/orchestrator-infra
 3. Install backstage chart with helm, setting orchestrator to be enabled.
 4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
 
+### Additional value configurations
+
+To install orchestrator, you must edit the values.yaml to include the follwing MAX_ENTRY_SIZE enviroment variable in the install-dynamic-plugins init container:
+```env:
+  - name: NPM_CONFIG_USERCONFIG
+    value: /opt/app-root/src/.npmrc.dynamic-plugins
+  - name: MAX_ENTRY_SIZE
+    value: '30000000'
+```
+You can do this by editing and overriding the base values.yaml for the backstage chart, which can be found [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml)
+
+### Enablement of Notifications Plugin
+To enable the notifications and signals plugin, please edit the dynamic plugin configmap post-installation and add the following:
+```      
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+Enabling these plugins will allow to recieve notifications from workflows running with Orchestrator.
+
+### Using Orchestrator while configuring an ExternalDB 
+
 To use orchestrator with an external DB, please follow the instructions in [our documentation](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)
 and populate the following values in the values.yaml:
 ```bash
@@ -291,8 +318,11 @@ and populate the following values in the values.yaml:
 ```
 Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
 
+To avoid setting varialbles inline in the helm command, you can prepeare an alternatve values file, like <orchestrator-overriding-values.yaml> that will encapsulate all value changes that are required smoothly install Orchestrator via the backstage helm chart.
+The default values.yaml can be found [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml)
 Finally, install the helm chart:
+
 ```
-helm install <release_name> charts/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
---set externalDBsecretRef=<cred-secret> --set externalDBName=example
+helm install <release_name> backstage/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
+--set externalDBsecretRef=<cred-secret> --set externalDBName=example --values=<orchestrator-overriding-values.yaml>
 ```


### PR DESCRIPTION
This PR adds some missing documentation for installing Orchestrator with the backstage chart. 

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
