### PR TITLE
chore: add MAX_ENTRY_SIZE var to values + doc change

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rhdh-chart&style=flat-square)](https://artifacthub.io/packages/search?repo=rhdh-chart)
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -347,6 +347,23 @@ helm install <release_name> charts/orchestrator-infra
 2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed.
 3. Install backstage chart with helm, setting orchestrator to be enabled.
 4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
+
+### Enablement of Notifications Plugin
+
+To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+```     
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+Enabling these plugins will allow you to recieve notifications from workflows running with Orchestrator.
+
+### Using Orchestrator while configuring an ExternalDB
 
 To use orchestrator with an external DB, please follow the instructions in [our documentation](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)
 and populate the following values in the values.yaml:

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -283,6 +283,23 @@ helm install <release_name> charts/orchestrator-infra
 3. Install backstage chart with helm, setting orchestrator to be enabled.
 4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
 
+### Enablement of Notifications Plugin
+
+To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+```      
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+- disabled: false
+  package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+Enabling these plugins will allow you to recieve notifications from workflows running with Orchestrator.
+
+### Using Orchestrator while configuring an ExternalDB 
+
 To use orchestrator with an external DB, please follow the instructions in [our documentation](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)
 and populate the following values in the values.yaml:
 ```bash

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -4493,6 +4493,10 @@
                                         {
                                             "name": "NPM_CONFIG_USERCONFIG",
                                             "value": "/opt/app-root/src/.npmrc.dynamic-plugins"
+                                        },
+                                        {
+                                            "name": "MAX_ENTRY_SIZE",
+                                            "value": "30000000"
                                         }
                                     ],
                                     "image": "{{ include \"backstage.image\" . }}",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -208,6 +208,9 @@ upstream:
         env:
           - name: NPM_CONFIG_USERCONFIG
             value: /opt/app-root/src/.npmrc.dynamic-plugins
+            # This following variable is required for orchestrator to startup properly.
+          - name: MAX_ENTRY_SIZE
+            value: "30000000"
         imagePullPolicy: Always
         volumeMounts:
           - mountPath: /dynamic-plugins-root


### PR DESCRIPTION
After the conversation on this now closed [PR](https://github.com/redhat-developer/rhdh-chart/pull/139), A new env-var was added to the default backstage values.yaml to allow orchestrator plugin to successfully install. 

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
