### PR TITLE
fix: documentation bug for backstage chart readme, in orchestrator

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.1
+version: 4.2.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -341,8 +341,8 @@ helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=
 
 ### Enablement of Notifications Plugin
 
-The orchestrator has a dependency on the Notifications plugin.
-To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+Workflows running with orchestrator may use the Notifications plugin.
+To enable the Notifications and Signals plugins, please edit the dynamic plugin configmap after the installation and add the following:
 
 ```     
 - disabled: false

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -325,19 +325,25 @@ upstream:
 ## Installing RHDH with Orchestrator
 
 Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, on boarding developers ,and user-made workflows of Backstage actions or external systems.
-Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the folloing way:
+Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the following way:
 
-1. Have an admin install the orchestrator-infra helm chart, which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
+1. Have an admin install the [orchestrator-infra helm chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
 ```
-helm install <release_name> charts/orchestrator-infra
+helm install <release_name> rhdh-developer/orchestrator-infra
 ```
 2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed.
-3. Install backstage chart with helm, setting orchestrator to be enabled.
-4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
+3. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
+4. Install backstage chart with helm, setting orchestrator to be enabled, like so:
+
+```
+helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
+```
 
 ### Enablement of Notifications Plugin
 
+The orchestrator has a dependency on the Notifications plugin.
 To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+
 ```     
 - disabled: false
   package: "./dynamic-plugins/dist/backstage-plugin-notifications"
@@ -360,8 +366,8 @@ and populate the following values in the values.yaml:
 ```
 Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
 
-Finally, install the helm chart:
+Finally, install the helm chart (including setting up the external DB):
 ```
-helm install <release_name> charts/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
+helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
 --set externalDBsecretRef=<cred-secret> --set externalDBName=example
 ```

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -342,7 +342,8 @@ helm install <release_name> redhat-developer/redhat-developer-hub-orchestrator-i
 helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
-  --set orchestrator.serverlessOperator.enabled=true```
+  --set orchestrator.serverlessOperator.enabled=true
+```
 
 ### Enablement of Notifications Plugin
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -352,7 +352,7 @@ For this, you must enable the Notifications and Signals plugins.
 To do so, you would need to edit the [default Helm values.yaml](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml) file, and add the plugins listed below to the global.dynamic.plugins list.
 Do this before installing the Helm Chart, or upgrade the Helm release with the new values file.
 
-```     
+```yaml
 - disabled: false
   package: "./dynamic-plugins/dist/backstage-plugin-notifications"
 - disabled: false

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -322,7 +322,7 @@ upstream:
       enabled: true
 ```
 
-## Installing RHDH with Orchestrator
+## Installing RHDH with Orchestrator on OpenShift
 
 Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, onboarding developers, and user-made workflows of Backstage actions or external systems.
 Orchestrator is a flavor of RHDH, and can be installed alongside RHDH in the same namespace and in the following way:
@@ -339,13 +339,17 @@ helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-inf
 3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
-helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
-```
+helm install <release_name> rhdh-developer/backstage \
+  --set orchestrator.enabled=true \
+  --set orchestrator.serverlessLogicOperator.enabled=true \
+  --set orchestrator.serverlessOperator.enabled=true```
 
 ### Enablement of Notifications Plugin
 
-Workflows running with orchestrator may use the Notifications plugin.
-To enable the Notifications and Signals plugins, please edit the dynamic plugin configmap after the installation and add the following:
+Workflows running with Orchestrator may use the Notifications plugin.
+For this, you must enable the Notifications and Signals plugins.
+To do so, you would need to edit the [default Helm values.yaml](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml) file, and add the plugins listed below to the global.dynamic.plugins list.
+Do this before installing the Helm Chart, or upgrade the Helm release with the new values file.
 
 ```     
 - disabled: false

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -324,16 +324,19 @@ upstream:
 
 ## Installing RHDH with Orchestrator
 
-Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, on boarding developers ,and user-made workflows of Backstage actions or external systems.
-Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the following way:
+Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, onboarding developers, and user-made workflows of Backstage actions or external systems.
+Orchestrator is a flavor of RHDH, and can be installed alongside RHDH in the same namespace and in the following way:
 
-1. Have an admin install the [orchestrator-infra helm chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
+1. Have an admin install the [orchestrator-infra Helm Chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the prerequisites required to deploy the Orchestrator-flavored RHDH. This process will include installing cluster-wide resources, so should be done with admin privileges:
 ```
-helm install <release_name> rhdh-developer/orchestrator-infra
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add backstage https://backstage.github.io/charts
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-infra
 ```
-2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed.
-3. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
-4. Install backstage chart with helm, setting orchestrator to be enabled, like so:
+2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. To do so, follow the post-install notes given by the chart, or see them [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/orchestrator-infra/templates/NOTES.txt)
+3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
 helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
@@ -364,10 +367,14 @@ and populate the following values in the values.yaml:
     externalDBsecretRef: <cred-secret>
     externalDBName: ""
 ```
-Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
+Please note that `externalDBName` is the name of the user-configured existing database, not the database that the orchestrator and sonataflow resources will use.
 
-Finally, install the helm chart (including setting up the external DB):
+Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
-helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
---set externalDBsecretRef=<cred-secret> --set externalDBName=example
+helm install <release_name> rhdh-developer/backstage \
+  --set orchestrator.enabled=true \
+  --set orchestrator.serverlessLogicOperator.enabled=true \
+  --set orchestrator.serverlessOperator.enabled=true \
+  --set orchestrator.sonataflowPlatform.externalDBsecretRef=<cred-secret> \
+  --set orchestrator.sonataflowPlatform.externalDBName=example
 ```

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
-![Version: 4.2.1](https://img.shields.io/badge/Version-4.2.1-informational?style=flat-square)
+![Version: 4.2.2](https://img.shields.io/badge/Version-4.2.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub.
@@ -333,13 +333,13 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add backstage https://backstage.github.io/charts
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-infra
+helm install <release_name> redhat-developer/redhat-developer-hub-orchestrator-infra
 ```
 2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. To do so, follow the post-install notes given by the chart, or see them [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/orchestrator-infra/templates/NOTES.txt)
 3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
-helm install <release_name> rhdh-developer/backstage \
+helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
   --set orchestrator.serverlessOperator.enabled=true```
@@ -375,7 +375,7 @@ Please note that `externalDBName` is the name of the user-configured existing da
 
 Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
-helm install <release_name> rhdh-developer/backstage \
+helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
   --set orchestrator.serverlessOperator.enabled=true \

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -262,7 +262,7 @@ upstream:
       enabled: true
 ```
 
-## Installing RHDH with Orchestrator
+## Installing RHDH with Orchestrator on OpenShift
 
 Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, onboarding developers, and user-made workflows of Backstage actions or external systems.
 Orchestrator is a flavor of RHDH, and can be installed alongside RHDH in the same namespace and in the following way: 
@@ -279,13 +279,17 @@ helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-inf
 3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
-helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
-```
+helm install <release_name> rhdh-developer/backstage \
+  --set orchestrator.enabled=true \
+  --set orchestrator.serverlessLogicOperator.enabled=true \
+  --set orchestrator.serverlessOperator.enabled=true```
 
 ### Enablement of Notifications Plugin
 
-Workflows running with orchestrator may use the Notifications plugin.
-To enable the Notifications and Signals plugins, please edit the dynamic plugin configmap after the installation and add the following:
+Workflows running with Orchestrator may use the Notifications plugin.
+For this, you must enable the Notifications and Signals plugins.
+To do so, you would need to edit the [default Helm values.yaml](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml) file, and add the plugins listed below to the global.dynamic.plugins list.
+Do this before installing the Helm Chart, or upgrade the Helm release with the new values file.
 
 ```      
 - disabled: false

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -264,16 +264,19 @@ upstream:
 
 ## Installing RHDH with Orchestrator
 
-Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, on boarding developers ,and user-made workflows of Backstage actions or external systems.
-Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the following way: 
+Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, onboarding developers, and user-made workflows of Backstage actions or external systems.
+Orchestrator is a flavor of RHDH, and can be installed alongside RHDH in the same namespace and in the following way: 
 
-1. Have an admin install the [orchestrator-infra helm chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
+1. Have an admin install the [orchestrator-infra Helm Chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the prerequisites required to deploy the Orchestrator-flavored RHDH. This process will include installing cluster-wide resources, so should be done with admin privileges:
 ```
-helm install <release_name> rhdh-developer/orchestrator-infra
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add backstage https://backstage.github.io/charts
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-infra
 ```
-2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. 
-3. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
-4. Install backstage chart with helm, setting orchestrator to be enabled, like so:
+2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. To do so, follow the post-install notes given by the chart, or see them [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/orchestrator-infra/templates/NOTES.txt)
+3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
 helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
@@ -304,10 +307,14 @@ and populate the following values in the values.yaml:
     externalDBsecretRef: <cred-secret>
     externalDBName: ""
 ```
-Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
+Please note that `externalDBName` is the name of the user-configured existing database, not the database that the orchestrator and sonataflow resources will use.
 
-Finally, install the helm chart (including setting up the external DB):
+Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
-helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
---set externalDBsecretRef=<cred-secret> --set externalDBName=example
+helm install <release_name> rhdh-developer/backstage \
+  --set orchestrator.enabled=true \
+  --set orchestrator.serverlessLogicOperator.enabled=true \
+  --set orchestrator.serverlessOperator.enabled=true \
+  --set orchestrator.sonataflowPlatform.externalDBsecretRef=<cred-secret> \
+  --set orchestrator.sonataflowPlatform.externalDBName=example
 ```

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -273,13 +273,13 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add backstage https://backstage.github.io/charts
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install <release_name> rhdh-developer/redhat-developer-hub-orchestrator-infra
+helm install <release_name> redhat-developer/redhat-developer-hub-orchestrator-infra
 ```
 2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. To do so, follow the post-install notes given by the chart, or see them [here](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/orchestrator-infra/templates/NOTES.txt)
 3. Install the `backstage` chart with Helm, enabling orchestrator, serverlessLogicOperator, and serverlessOperator, like so:
 
 ```
-helm install <release_name> rhdh-developer/backstage \
+helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
   --set orchestrator.serverlessOperator.enabled=true```
@@ -315,7 +315,7 @@ Please note that `externalDBName` is the name of the user-configured existing da
 
 Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
-helm install <release_name> rhdh-developer/backstage \
+helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
   --set orchestrator.serverlessOperator.enabled=true \

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -282,7 +282,8 @@ helm install <release_name> redhat-developer/redhat-developer-hub-orchestrator-i
 helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.serverlessLogicOperator.enabled=true \
-  --set orchestrator.serverlessOperator.enabled=true```
+  --set orchestrator.serverlessOperator.enabled=true
+```
 
 ### Enablement of Notifications Plugin
 
@@ -291,7 +292,7 @@ For this, you must enable the Notifications and Signals plugins.
 To do so, you would need to edit the [default Helm values.yaml](https://github.com/redhat-developer/rhdh-chart/blob/main/charts/backstage/values.yaml) file, and add the plugins listed below to the global.dynamic.plugins list.
 Do this before installing the Helm Chart, or upgrade the Helm release with the new values file.
 
-```      
+```yaml
 - disabled: false
   package: "./dynamic-plugins/dist/backstage-plugin-notifications"
 - disabled: false

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -265,19 +265,25 @@ upstream:
 ## Installing RHDH with Orchestrator
 
 Orchestrator brings serverless workflows into Backstage, focusing on the journey for application migration to the cloud, on boarding developers ,and user-made workflows of Backstage actions or external systems.
-Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the folloing way: 
+Orchestrator is a flavor of RHDH, and can be installed alongside the RHDH in the same namespace and in the following way: 
 
-1. Have an admin install the orchestrator-infra helm chart, which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
+1. Have an admin install the [orchestrator-infra helm chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/orchestrator-infra#readme), which will install the pre-requisites required to install RHDH flavored Orchestrator. This proccess will include installing cluster-wide resources, so should be done with admin privileges
 ```
-helm install <release_name> charts/orchestrator-infra
+helm install <release_name> rhdh-developer/orchestrator-infra
 ```
 2. Manually approve the Install Plans created by the chart, and wait for the Openshift Serverless and Openshift Serverless Logic Operators to be deployed. 
-3. Install backstage chart with helm, setting orchestrator to be enabled.
-4. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
+3. Enable serverlessLogicOperator and serverlessOperator in the backstage values.
+4. Install backstage chart with helm, setting orchestrator to be enabled, like so:
+
+```
+helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true
+```
 
 ### Enablement of Notifications Plugin
 
+The orchestrator has a dependency on the Notifications plugin.
 To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+
 ```      
 - disabled: false
   package: "./dynamic-plugins/dist/backstage-plugin-notifications"
@@ -300,8 +306,8 @@ and populate the following values in the values.yaml:
 ```
 Please note that externalDBName is the name of the user-configured existing database, not the database that orchestrator and sonataflow resources will use.
 
-Finally, install the helm chart:
+Finally, install the helm chart (including setting up the external DB):
 ```
-helm install <release_name> charts/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
+helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=true --set orchestrator.serverlessLogicOperator.enabled=true --set orchestrator.serverlessOperator.enabled=true \
 --set externalDBsecretRef=<cred-secret> --set externalDBName=example
 ```

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -281,8 +281,8 @@ helm install <release_name> rhdh-developer/backstage --set orchestrator.enabled=
 
 ### Enablement of Notifications Plugin
 
-The orchestrator has a dependency on the Notifications plugin.
-To enable the notifications and signals plugin, please edit the dynamic plugin configmap after the installation and add the following:
+Workflows running with orchestrator may use the Notifications plugin.
+To enable the Notifications and Signals plugins, please edit the dynamic plugin configmap after the installation and add the following:
 
 ```      
 - disabled: false


### PR DESCRIPTION
This PR will close the outstanding issues addressed in this [doc bug](https://issues.redhat.com/browse/RHIDP-7255).  

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
