### PR TITLE
chore(CI builds): Expose an in-cluster Helm repo off of the OCI chart pulled

### DIFF
--- a/.rhdh/scripts/install.sh
+++ b/.rhdh/scripts/install.sh
@@ -126,7 +126,7 @@ spec:
     url: http://helm-repo.${namespace}.svc.cluster.local/charts
 EOF
 
-  oc apply -f repo.yaml || kubctl apply -f repo.yaml
+  oc apply -f repo.yaml || kubectl apply -f repo.yaml
   popd  >/dev/null 2>&1 || exit 1
 
   # clean up temp files

--- a/.rhdh/scripts/install.sh
+++ b/.rhdh/scripts/install.sh
@@ -112,7 +112,7 @@ spec:
   - port: 80
     targetPort: 8080
 EOF
-  oc apply -f helm-repo.yaml || kubctl apply -f helm-repo.yaml
+  oc apply -f helm-repo.yaml || kubectl apply -f helm-repo.yaml
 
   cat <<EOF > repo.yaml
 apiVersion: helm.openshift.io/v1beta1

--- a/.rhdh/scripts/install.sh
+++ b/.rhdh/scripts/install.sh
@@ -60,15 +60,70 @@ if [[ "$CV" == *"-CI" ]] || [[ $chartrepo -eq 1 ]]; then
   mkdir -p /tmp/"$CV"-unpacked && pushd /tmp/"$CV"-unpacked >/dev/null 2>&1 || exit 1
   helm pull oci://quay.io/rhdh/chart --version "$CV" -d /tmp/"$CV"-unpacked # get tarball
   helm repo index /tmp/"$CV"-unpacked # create index.yaml
+
+  # HelmChartRepository does not support OCI artifacts.
+  # Host an in-cluster Helm repo serving both the index and chart files.
+  if oc -n "$namespace" get configmap helm-repo-files > /dev/null; then
+    oc -n "$namespace" delete configmap helm-repo-files
+  fi
+  oc -n "$namespace" create configmap helm-repo-files \
+    --from-file=/tmp/"$CV"-unpacked/index.yaml \
+    --from-file=/tmp/"$CV"-unpacked/chart-${CV}.tgz
+  cat <<EOF > helm-repo.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-repo
+  annotations:
+    rhdh.redhat.com/chart-version: "$CV"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm-repo
+  template:
+    metadata:
+      labels:
+        app: helm-repo
+      annotations:
+        rhdh.redhat.com/chart-version: "$CV"
+    spec:
+      containers:
+      - name: nginx
+        image: quay.io/openshifttest/nginx-alpine:1.2.4
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: chart-vol
+          mountPath: /data/http/charts
+      volumes:
+      - name: chart-vol
+        configMap:
+          name: helm-repo-files
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: helm-repo
+spec:
+  selector:
+    app: helm-repo
+  ports:
+  - port: 80
+    targetPort: 8080
+EOF
+  oc apply -f helm-repo.yaml || kubctl apply -f helm-repo.yaml
+
   cat <<EOF > repo.yaml
 apiVersion: helm.openshift.io/v1beta1
 kind: HelmChartRepository
 metadata:
   name: rhdh-next-ci-repo
+  annotations:
+    rhdh.redhat.com/chart-version: "$CV"
 spec:
   connectionConfig:
-    file: >-
-      ./index.yaml
+    url: http://helm-repo.${namespace}.svc.cluster.local/charts
 EOF
 
   oc apply -f repo.yaml || kubctl apply -f repo.yaml


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

https://github.com/redhat-developer/rhdh-chart/pull/152 introduced the automatic generation of a `HelmChartRepository` Resource in the cluster, but the problem is that it does not support neither OCI artifacts nor `file` references in its `connectionConfig`. It only supports repos served over HTTP.
This PR extends this approach by also deploying an in-cluster (not exposed publicly) web server that serves the necessary Helm repo files (index.yaml and chart archive from the OCI artifact).
With this, the corresponding chart CI version now shows up in the list on the OCP console, and it is possible to upgrade via the web console after deploying the Chart via CLI.

![Screenshot From 2025-05-15 16-23-57](https://github.com/user-attachments/assets/39c7a051-d6d0-4fd4-98c7-1aeb1d4e407f)

![Screenshot From 2025-05-15 16-23-29](https://github.com/user-attachments/assets/4c987a68-6e95-4530-8f46-b8f1cf904b8a)

## Existing or Associated Issue(s)

Ref: https://issues.redhat.com/browse/RHIDP-7251
Ref: https://issues.redhat.com/browse/RHIDP-6668

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

/cc @nickboldt @Omar-AlJaljuli @gustavolira 