### PR TITLE
fix: Fix the images used by the Orchestrator DB creation Job

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -50,4 +50,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.2.6
+version: 4.2.7

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
-![Version: 4.2.6](https://img.shields.io/badge/Version-4.2.6-informational?style=flat-square)
+![Version: 4.2.7](https://img.shields.io/badge/Version-4.2.7-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Red Hat Developer Hub is a Red Hat supported version of Backstage.
@@ -184,12 +184,12 @@ Kubernetes: `>= 1.27.0-0`
 | orchestrator.enabled |  | bool | `false` |
 | orchestrator.serverlessLogicOperator.enabled |  | bool | `true` |
 | orchestrator.serverlessOperator.enabled |  | bool | `true` |
-| orchestrator.sonataflowPlatform.createDBJobImage | Image for the container used by the create-db job | string | `"postgres:15"` |
+| orchestrator.sonataflowPlatform.createDBJobImage | Image for the container used by the create-db job | string | `"{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"` |
 | orchestrator.sonataflowPlatform.eventing.broker.name |  | string | `""` |
 | orchestrator.sonataflowPlatform.eventing.broker.namespace |  | string | `""` |
 | orchestrator.sonataflowPlatform.externalDBName | Name for the user-configured external Database | string | `""` |
 | orchestrator.sonataflowPlatform.externalDBsecretRef | Secret name for the user-created secret to connect an external DB | string | `""` |
-| orchestrator.sonataflowPlatform.initContainerImage | Image for the init container used by the create-db job | string | `"busybox"` |
+| orchestrator.sonataflowPlatform.initContainerImage | Image for the init container used by the create-db job | string | `"{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"` |
 | orchestrator.sonataflowPlatform.monitoring.enabled |  | bool | `true` |
 | orchestrator.sonataflowPlatform.resources.limits.cpu |  | string | `"500m"` |
 | orchestrator.sonataflowPlatform.resources.limits.memory |  | string | `"1Gi"` |

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -92,18 +92,25 @@ spec:
     spec:
       initContainers:
         - name: wait-for-db
-          image: {{ .Values.orchestrator.sonataflowPlatform.initContainerImage }}
+          image: "{{- tpl .Values.orchestrator.sonataflowPlatform.initContainerImage . -}}"
           command:
-            - sh
+            - bash
             - -c
-{{- if .Values.upstream.postgresql.enabled }}
-            - "until nc -z {{ .Release.Name }}-postgresql 5432; do echo 'Waiting for DB...'; sleep 2; done"
-{{- else }}
-            - "until nc -z {{ .Values.upstream.backstage.appConfig.backend.database.connection.host }} {{ .Values.upstream.backstage.appConfig.backend.database.connection.port }}; do echo 'Waiting for external DB...'; sleep 2; done"
-{{- end }}
+            - |
+              {{- if .Values.upstream.postgresql.enabled }}
+              dbHost="{{ .Release.Name }}-postgresql"
+              dbPort="5432"
+              {{- else }}
+              dbHost="{{ .Values.upstream.backstage.appConfig.backend.database.connection.host }}"
+              dbPort="{{ .Values.upstream.backstage.appConfig.backend.database.connection.port }}"
+              {{- end }}
+              until timeout --preserve-status --kill-after=3 2 bash -c ">/dev/tcp/${dbHost}/${dbPort}"; do
+                echo 'Waiting for DB...'
+                sleep 2
+              done
       containers:
       - name: psql
-        image: {{ .Values.orchestrator.sonataflowPlatform.createDBJobImage }}
+        image: "{{- tpl .Values.orchestrator.sonataflowPlatform.createDBJobImage . -}}"
         env:
         - name: PGPASSWORD
           valueFrom:
@@ -125,9 +132,3 @@ spec:
       restartPolicy: Never
   backoffLimit: 2
 {{- end }}
-
-
-
-
-
-

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -372,7 +372,7 @@ orchestrator:
     externalDBName: ""
 
     # -- Image for the init container used by the create-db job
-    initContainerImage: busybox
+    initContainerImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
 
     # -- Image for the container used by the create-db job
-    createDBJobImage: "postgres:15"
+    createDBJobImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"


### PR DESCRIPTION
## Description of the change

We should not use container images from Docker Hub. We should also be consistent and use images that have their counterpart available on registry.redhat.io when publishing the Helm Chart.
This PR makes sure to reuse the existing DB image in the Orchestrator DB creation Job. This way, there won't be any impact on our publishing process or our airgap docs.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

Fixes https://issues.redhat.com/browse/RHIDP-7457

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
The procedure to [install the Orchestrator-flavored RHDH on OpenShift](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/backstage#installing-rhdh-with-orchestrator-on-openshift) should continue to work.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

/cc @elai-shalev