### PR TITLE
chore: Review and update owners file and authorize jobs with the current Install group members

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(fromJSON('["coreydaley","gazarenkov","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot", "Fortune-Ndlovu", "subhashkhileri", "zdrapela"]'), github.actor)) && 'internal' || 'external' }}
+      contains(fromJSON('["coreydaley","gazarenkov","kadel","nickboldt","rm3l","kim-tsao","Fortune-Ndlovu","subhashkhileri","zdrapela","openshift-cherrypick-robot", "Fortune-Ndlovu", "subhashkhileri", "zdrapela"]'), github.actor)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,16 @@
+# if adding/removing approvers, remember to update the .github/workflows/*.yaml files
+# to add/remove them from the authorize job(s), if any
 approvers:
- - coreydaley
- - davidfestal
- - gazarenkov
- - kadel
- - nickboldt
  - rm3l
- - tumido
+ - gazarenkov
+ - nickboldt
+ - kim-tsao
+ - coreydaley
+ - kadel
+
+reviewers:
+ - rm3l
+ - gazarenkov
+ - Fortune-Ndlovu
+ - subhashkhileri
+ - zdrapela


### PR DESCRIPTION
## Description of the change

Similar to https://github.com/redhat-developer/rhdh-operator/pull/1243, this reviews and updates the owners file and authorize jobs with a relevant list of people, including the current Install group members.

## Existing or Associated Issue(s)

&mdash;

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
