### PR TITLE
chore: Update PR Template checklist with reminder to check the `orchestrator-infra` CRDs versions [RHIDP-6694]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,30 @@
 <!--
 Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements
 
-Please remember to:
-- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
-  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-- ensure there are no merge commits!
+Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.
 
- -->
+-->
 
 ## Description of the change
 
 <!-- Describe the change being requested. -->
 
-## Existing or Associated Issue(s)
+## Which issue(s) does this PR fix or relate to
 
 <!-- List any related issues. -->
 
-## Additional Information
+- _JIRA_issue_link_
 
- <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
+## How to test changes / Special notes to the reviewer
+
+<!--
+Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
+-->
 
 ## Checklist
 
-- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
-- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
-- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
-- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
+- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
+- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
+- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
+- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
+- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR mainly updates the PR Template checklist to include a reminder to check the Knative CRDs versions if needed.
This is the first step until we can enforce that check automatically.

## Existing or Associated Issue(s)

Relates to https://issues.redhat.com/browse/RHIDP-6694

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
