### PR TITLE
Backstage chart: fixing RHIDP/7806 in Orchestrator's SFP config

### DIFF
--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -187,7 +187,9 @@ Kubernetes: `>= 1.27.0-0`
 | orchestrator.sonataflowPlatform.createDBJobImage | Image for the container used by the create-db job | string | `"{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"` |
 | orchestrator.sonataflowPlatform.eventing.broker.name |  | string | `""` |
 | orchestrator.sonataflowPlatform.eventing.broker.namespace |  | string | `""` |
+| orchestrator.sonataflowPlatform.externalDBHost | Host for the user-configured external Database | string | `""` |
 | orchestrator.sonataflowPlatform.externalDBName | Name for the user-configured external Database | string | `""` |
+| orchestrator.sonataflowPlatform.externalDBPort | Port for the user-configured external Database | string | `""` |
 | orchestrator.sonataflowPlatform.externalDBsecretRef | Secret name for the user-created secret to connect an external DB | string | `""` |
 | orchestrator.sonataflowPlatform.initContainerImage | Image for the init container used by the create-db job | string | `"{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"` |
 | orchestrator.sonataflowPlatform.monitoring.enabled |  | bool | `true` |
@@ -373,13 +375,20 @@ and populate the following values in the values.yaml:
 ```bash
     externalDBsecretRef: <cred-secret>
     externalDBName: ""
+    externalDBHost: ""
+    externalDBPort: ""
 ```
+The values for externalDBHost and externalDBPort should match the ones configured in the cred-secret.
+
 Please note that `externalDBName` is the name of the user-configured existing database, not the database that the orchestrator and sonataflow resources will use.
+A Job will run to create the 'sonataflow' databse in the external database for the workflows to use.
 
 Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
 helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.sonataflowPlatform.externalDBsecretRef=<cred-secret> \
-  --set orchestrator.sonataflowPlatform.externalDBName=example
+  --set orchestrator.sonataflowPlatform.externalDBName=example \
+  --set orchestrator.sonataflowPlatform.externalDBHost=example \
+  --set orchestrator.sonataflowPlatform.externalDBPort=example
 ```

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -310,13 +310,20 @@ and populate the following values in the values.yaml:
 ```bash
     externalDBsecretRef: <cred-secret>
     externalDBName: ""
+    externalDBHost: ""
+    externalDBPort: ""
 ```
+The values for externalDBHost and externalDBPort should match the ones configured in the cred-secret. 
+
 Please note that `externalDBName` is the name of the user-configured existing database, not the database that the orchestrator and sonataflow resources will use.
+A Job will run to create the 'sonataflow' databse in the external database for the workflows to use.
 
 Finally, install the Helm Chart (including [setting up the external DB](https://github.com/redhat-developer/rhdh-chart/blob/main/docs/external-db.md)):
 ```
 helm install <release_name> redhat-developer/backstage \
   --set orchestrator.enabled=true \
   --set orchestrator.sonataflowPlatform.externalDBsecretRef=<cred-secret> \
-  --set orchestrator.sonataflowPlatform.externalDBName=example
+  --set orchestrator.sonataflowPlatform.externalDBName=example \
+  --set orchestrator.sonataflowPlatform.externalDBHost=example \
+  --set orchestrator.sonataflowPlatform.externalDBPort=example
 ```

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -35,7 +35,7 @@ spec:
       enabled: true
       persistence:
         postgresql:
-          {{- if .Values.upstream.postgresql.enabled }}
+{{- if .Values.upstream.postgresql.enabled }}
           secretRef:
             name: {{ .Release.Name }}-postgresql-svcbind-postgres
             userKey: username
@@ -44,23 +44,23 @@ spec:
             name: {{ .Release.Name }}-postgresql
             namespace: {{ .Release.Namespace }}
             databaseName: sonataflow
-          {{- else }}
+{{- else }}
           secretRef:
             name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef }}
             userKey: POSTGRES_USER
             passwordKey: POSTGRES_PASSWORD
-          jdbcUrl: jdbc:postgresql://{{ .Values.upstream.backstage.appConfig.backend.database.connection.host}}:{{ .Values.upstream.backstage.appConfig.backend.database.connection.port}}/sonataflow?currentSchema=data-index-service
-          {{- end }}
-      {{- if .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
+          jdbcUrl: jdbc:postgresql://{{ .Values.orchestrator.sonataflowPlatform.externalDBHost }}:{{ .Values.orchestrator.sonataflowPlatform.externalDBPort }}/{{ .Values.orchestrator.sonataflowPlatform.externalDBName }}?currentSchema=data-index-service
+{{- end }}
+{{- if .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
       podTemplate:
         container:
           image: {{ .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
-      {{- end }}
+{{- end }}
     jobService:
       enabled: true
       persistence:
         postgresql:
-          {{- if .Values.upstream.postgresql.enabled }}
+{{- if .Values.upstream.postgresql.enabled }}
           secretRef:
             name: {{ .Release.Name }}-postgresql-svcbind-postgres
             userKey: username
@@ -69,18 +69,18 @@ spec:
             name: {{ .Release.Name }}-postgresql
             namespace: {{ .Release.Namespace }}
             databaseName: sonataflow
-          {{- else }}
+{{- else }}
           secretRef:
             name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
             userKey: POSTGRES_USER
             passwordKey: POSTGRES_PASSWORD
-          jdbcUrl: jdbc:postgresql://{{ .Values.upstream.backstage.appConfig.backend.database.connection.host}}:{{ .Values.upstream.backstage.appConfig.backend.database.connection.port}}/sonataflow?currentSchema=jobs-service
-          {{- end }}
-      {{- if .Values.orchestrator.sonataflowPlatform.jobServiceImage }}
+          jdbcUrl: jdbc:postgresql://{{ .Values.orchestrator.sonataflowPlatform.externalDBHost }}:{{ .Values.orchestrator.sonataflowPlatform.externalDBPort }}/{{ .Values.orchestrator.sonataflowPlatform.externalDBName }}?currentSchema=jobs-service
+{{- end }}
+{{- if .Values.orchestrator.sonataflowPlatform.jobServiceImage }}
       podTemplate:
         container:
           image: {{ .Values.orchestrator.sonataflowPlatform.jobServiceImage }}
-      {{- end }}
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -88,6 +88,7 @@ metadata:
   name: {{ .Release.Name }}-create-sonataflow-database
   namespace: {{ .Release.Namespace }}
 spec:
+  activeDeadlineSeconds: 120
   template:
     spec:
       initContainers:
@@ -97,37 +98,59 @@ spec:
             - bash
             - -c
             - |
-              {{- if .Values.upstream.postgresql.enabled }}
+{{- if .Values.upstream.postgresql.enabled }}
               dbHost="{{ .Release.Name }}-postgresql"
               dbPort="5432"
-              {{- else }}
-              dbHost="{{ .Values.upstream.backstage.appConfig.backend.database.connection.host }}"
-              dbPort="{{ .Values.upstream.backstage.appConfig.backend.database.connection.port }}"
-              {{- end }}
-              until timeout --preserve-status --kill-after=3 2 bash -c ">/dev/tcp/${dbHost}/${dbPort}"; do
+{{- else }}
+              dbHost=${POSTGRES_HOST}
+              dbPort=${POSTGRES_PORT}
+{{- end }}
+              until timeout 2 bash -c ">/dev/tcp/$dbHost/$dbPort"; do
                 echo 'Waiting for DB...'
                 sleep 2
               done
+{{- if not .Values.upstream.postgresql.enabled }}
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
+                  key: POSTGRES_PORT
+{{- end }}
       containers:
       - name: psql
         image: "{{- tpl .Values.orchestrator.sonataflowPlatform.createDBJobImage . -}}"
         env:
+{{- if .Values.upstream.postgresql.enabled }}
         - name: PGPASSWORD
           valueFrom:
-{{- if .Values.upstream.postgresql.enabled }}
             secretKeyRef:
               name: {{ .Release.Name }}-postgresql-svcbind-postgres
               key: password
+{{- else }}
+          - name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
+                key: POSTGRES_HOST
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
+                key: POSTGRES_USER
+{{- end }}
         command: [ "sh", "-c" ]
+{{- if .Values.upstream.postgresql.enabled }}
         args:
           - "psql -h {{ .Release.Name }}-postgresql -U postgres -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"
 {{- else }}
-            secretKeyRef:
-              name: {{ .Values.orchestrator.sonataflowPlatform.externalDBsecretRef}}
-              key: POSTGRES_PASSWORD
-        command: [ "sh", "-c" ]
         args:
-          - "psql -h {{ .Values.upstream.backstage.appConfig.backend.database.connection.host }} -U {{ .Values.upstream.backstage.appConfig.backend.database.connection.user }} -d {{ .Values.orchestrator.sonataflowPlatform.externalDBName }} -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"
+          - "psql -h ${POSTGRES_HOST} -U ${POSTGRES_USER} -d {{ .Values.orchestrator.sonataflowPlatform.externalDBName }} -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"
 {{- end }}
       restartPolicy: Never
   backoffLimit: 2

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -155,9 +155,19 @@
                             "title": "eventing configuration",
                             "type": "object"
                         },
+                        "externalDBHost": {
+                            "additionalProperties": false,
+                            "title": "Host for the user-configured external Database",
+                            "type": "string"
+                        },
                         "externalDBName": {
                             "additionalProperties": false,
                             "title": "Name for the user-configured external Database",
+                            "type": "string"
+                        },
+                        "externalDBPort": {
+                            "additionalProperties": false,
+                            "title": "Port for the user-configured external Database",
                             "type": "string"
                         },
                         "externalDBsecretRef": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -322,6 +322,16 @@
                             "type": "string",
                             "additionalProperties": false
                         },
+                        "externalDBHost": {
+                            "title": "Host for the user-configured external Database",
+                            "type": "string",
+                            "additionalProperties": false
+                        },
+                        "externalDBPort": {
+                            "title": "Port for the user-configured external Database",
+                            "type": "string",
+                            "additionalProperties": false
+                        },
                         "initContainerImage": {
                             "title": "Image for the init container used by the create-db job",
                             "type": "string",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -371,6 +371,12 @@ orchestrator:
     # -- Name for the user-configured external Database
     externalDBName: ""
 
+    # -- Host for the user-configured external Database
+    externalDBHost: ""
+
+    # -- Port for the user-configured external Database
+    externalDBPort: ""
+
     # -- Image for the init container used by the create-db job
     initContainerImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
 


### PR DESCRIPTION
This PR will fix some issues addressed in [RHIDP-7806](https://issues.redhat.com/browse/RHIDP-7806). When using Orchestrator with an external db, environment variables were not passed to the job responsible to create the new 'sonataflow' database. This caused the SonataflowPlatform to be faulty, and the Job service and Data Index to fail. 

This issue was fixed in this PR. 

 
## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
