### PR TITLE
fix: avoid double helm upgrade in CI install script

### DIFF
--- a/.rhdh/scripts/install.sh
+++ b/.rhdh/scripts/install.sh
@@ -133,10 +133,7 @@ EOF
   rm -fr /tmp/"$CV"-unpacked
 fi
 
-# 1. install (or upgrade)
-helm upgrade redhat-developer-hub -i "${CHART_URL}" --version "$CV"
-
-# 2. collect values
+# collect values
 PASSWORD=$(kubectl get secret redhat-developer-hub-postgresql -o jsonpath="{.data.password}" | base64 -d)
 if [[ $(oc auth can-i get route/openshift-console) == "yes" ]]; then
   CLUSTER_ROUTER_BASE=$(oc get route console -n openshift-console -o=jsonpath='{.spec.host}' | sed 's/^[^.]*\.//')
@@ -148,7 +145,7 @@ elif [[ -z $CLUSTER_ROUTER_BASE ]]; then
   exit 1
 fi
 
-# 3. change values
+# change values
 helm upgrade redhat-developer-hub -i "${CHART_URL}" --version "$CV" \
     --set global.clusterRouterBase="${CLUSTER_ROUTER_BASE}" \
     --set global.postgresql.auth.password="$PASSWORD"


### PR DESCRIPTION
## Description of the change

Previously, .rhdh/scripts/install.sh called helm upgrade twice:
- Once without any values, then again with --set clusterRouterBase, postgresql.password, etc.
This caused two deployment rollouts:
- Helm created Revision 1, deployed it, then immediately created Revision 2, rolling again. Resulting in two ReplicaSets, and temporary pod churn

This PR removes the first redundant helm upgrade, keeping only the final call with full values.
Verified:
- Only Revision 1 appears in oc rollout history
- Only 1 ReplicaSet is created
- No second deployment or image pull

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- https://issues.redhat.com/browse/RHIDP-7500 

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
