### PR TITLE
ci: Add CI values file for testing the Orchestrator flavor [RHIDP-7469]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,9 +54,12 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch "${{ github.event.pull_request.base.ref }}")
-          if [[ -n "$changed" ]]; then
+          listChanged=$(ct list-changed --target-branch "${{ github.event.pull_request.base.ref }}")
+          if [[ -n "$listChanged" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            if grep 'charts/backstage' <<< "$listChanged"; then
+              echo "backstageChartChanged=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Add Helm Repositories
@@ -129,6 +132,22 @@ jobs:
           curl -L "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh" -o install-olm.sh
           chmod +x install-olm.sh
           ./install-olm.sh "${OLM_VERSION}"
+
+      # https://issues.redhat.com/browse/RHIDP-7469 - minimal testing of the Orchestrator flavor.
+      # The Orchestrator flavor requires installing the orchestrator-infra chart as a prerequisite,
+      # but the OpenShift Serverless and Serverless Operators installed by this chart are available only on OCP (from the Red Hat Catalog).
+      # For the simple testing that we are doing here on a vanilla K8s cluster, we only need both the Knative and SonataFlow CRDs.
+      # TODO(rm3l): Update this when/if there is an upstream counterpart installable via OLM.
+      # NOTES:
+      # - Serverless 1.35 corresponds to Knative 1.18
+      # - Serverless Logic 1.35 corresponds to Sonataflow 1.43
+      - name: Install Knative and SonataFlow CRDs via the orchestrator-infra-chart as minimum prerequisite for testing the Orchestrator flavor
+        if: steps.list-changed.outputs.backstageChartChanged == 'true'
+        run: |
+          for crdDir in charts/orchestrator-infra/crds/*; do
+            kubectl apply -f "${crdDir}"
+          done
+          kubectl apply -f https://github.com/apache/incubator-kie-kogito-serverless-operator/releases/download/v1.43.1/operator.yaml
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -50,4 +50,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.2.11
+version: 4.2.12

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
-![Version: 4.2.11](https://img.shields.io/badge/Version-4.2.11-informational?style=flat-square)
+![Version: 4.2.12](https://img.shields.io/badge/Version-4.2.12-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Red Hat Developer Hub is a Red Hat supported version of Backstage.

--- a/charts/backstage/ci/with-orchestrator-values.yaml
+++ b/charts/backstage/ci/with-orchestrator-values.yaml
@@ -1,0 +1,20 @@
+route:
+  enabled: false
+
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+global:
+  dynamic:
+    plugins:
+      # Enable additional plugins, which should be merged with the Orchestrator plugins
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+        disabled: false
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+        disabled: false
+
+orchestrator:
+  enabled: true


### PR DESCRIPTION
## Description of the change

This PR adds a CI values file in the `backstage` chart for testing this Chart with the Orchestrator enabled. Since installing the Orchestrator flavor requires the orchestrator-infra chart, and the operators the orchestrator-infra chart installs are only available in the RH CatalogSource, this tries to install the bare minimum requirements (Knative and SonataFlow CRDs) to have a running instance of the app.
The scope of the tests in the backstage chart is not to have complete app E2E tests, but instead to make sure that the chart is installable and the app starts as expected. So this should be fine for having some minimal testing of this. There is a different Story for full E2E orchestrator testing.

## Which issue(s) does this PR fix or relate to

Fixes https://issues.redhat.com/browse/RHIDP-7469

## How to test changes / Special notes to the reviewer

We can see in the [workflow run](https://github.com/redhat-developer/rhdh-chart/actions/runs/15902171730/job/44847543208?pr=177#step:14:8061) that the new CI values is being picked in the CI.

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Add CI support for testing the Orchestrator flavor by introducing a dedicated values file, extending the test workflow to detect Backstage chart changes and install required CRDs, and bump the Backstage chart version.

Enhancements:
- Introduce a with-orchestrator-values.yaml file to define minimal configuration for testing the Orchestrator flavor

CI:
- Detect Backstage chart changes in the test workflow and conditionally install Knative and SonataFlow CRDs for Orchestrator tests

Chores:
- Bump Backstage Helm chart version to 4.2.12