### PR TITLE
chore: link to 1.6 docs, which have changed path again (RHIDP-7643) [main]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -14,10 +14,7 @@ annotations:
   charts.openshift.io/supportURL: https://access.redhat.com/support
 apiVersion: v2
 description: |
-  Red Hat Developer Hub is a Red Hat supported version of Backstage.
-  It comes with pre-built plug-ins and configuration settings, supports use of an external database, and can
-  help streamline the process of setting up a self-managed internal
-  developer portal for adopters who are just starting out.
+  A Helm chart for deploying Red Hat Developer Hub.
 
   The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 dependencies:

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -19,7 +19,7 @@ description: |
   help streamline the process of setting up a self-managed internal
   developer portal for adopters who are just starting out.
 
-  The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/telemetry_data_collection/index
+  The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -50,4 +50,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.2.11
+version: 4.2.12

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -14,7 +14,7 @@ annotations:
   charts.openshift.io/supportURL: https://access.redhat.com/support
 apiVersion: v2
 description: |
-  A Helm chart for deploying Red Hat Developer Hub.
+  A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
 
   The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 dependencies:

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,13 +1,10 @@
 
-# RHDH Backstage Helm Chart for OpenShift (Community Version)
+# RHDH Backstage Helm Chart for OpenShift
 
 ![Version: 4.2.12](https://img.shields.io/badge/Version-4.2.12-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-Red Hat Developer Hub is a Red Hat supported version of Backstage.
-It comes with pre-built plug-ins and configuration settings, supports use of an external database, and can
-help streamline the process of setting up a self-managed internal
-developer portal for adopters who are just starting out.
+A Helm chart for deploying Red Hat Developer Hub.
 
 The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -9,7 +9,7 @@ It comes with pre-built plug-ins and configuration settings, supports use of an 
 help streamline the process of setting up a self-managed internal
 developer portal for adopters who are just starting out.
 
-The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/telemetry_data_collection/index
+The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 
 **Homepage:** <https://red.ht/rhdh>
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -4,7 +4,7 @@
 ![Version: 4.2.12](https://img.shields.io/badge/Version-4.2.12-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-A Helm chart for deploying Red Hat Developer Hub.
+A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
 
 The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/telemetry_data_collection_and_analysis/index
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift (Community Version)
 
-![Version: 4.2.11](https://img.shields.io/badge/Version-4.2.11-informational?style=flat-square)
+![Version: 4.2.12](https://img.shields.io/badge/Version-4.2.12-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Red Hat Developer Hub is a Red Hat supported version of Backstage.

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -1,4 +1,4 @@
-# RHDH Backstage Helm Chart for OpenShift (Community Version)
+# RHDH Backstage Helm Chart for OpenShift
 
 {{ template "chart.deprecationWarning" . }}
 

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.0.5
+version: 0.1.0

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
-# Orchestrator Infra Chart for OpenShift (Community Version)
+# Orchestrator Infra Chart for OpenShift
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -1,4 +1,4 @@
-# Orchestrator Infra Chart for OpenShift (Community Version)
+# Orchestrator Infra Chart for OpenShift
 
 {{ template "chart.deprecationWarning" . }}
 


### PR DESCRIPTION
### What does this PR do?

chore: link to 1.6 docs, which have changed path again

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-7643


### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

## Summary by Sourcery

Documentation:
- Point telemetry docs link in Chart.yaml and README to version 1.6 path