### PR TITLE
chore: remove link to https://github.com/rhdh-bot/openshift-helm-charts as it's deprecated / dead; new CI process uses quay.io/rhdh/chart, which is mentioned in the readme already (RHIDP-7643)

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 3.2.5
+version: 3.2.6

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 3.2.5](https://img.shields.io/badge/Version-3.2.5-informational?style=flat-square)
+![Version: 3.2.6](https://img.shields.io/badge/Version-3.2.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -14,7 +14,6 @@ The telemetry data collection feature is enabled by default. Red Hat Developer H
 
 For the **PRODUCTIZED** version of this chart, see:
 
-* https://github.com/rhdh-bot/openshift-helm-charts - CI builds for testing purposes only
 * https://github.com/openshift-helm-charts/charts - official releases to https://charts.openshift.io/
 
 ## Maintainers

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -13,7 +13,6 @@
 
 For the **PRODUCTIZED** version of this chart, see:
 
-* https://github.com/rhdh-bot/openshift-helm-charts - CI builds for testing purposes only
 * https://github.com/openshift-helm-charts/charts - official releases to https://charts.openshift.io/
 
 {{ template "chart.maintainersSection" . }}


### PR DESCRIPTION
### What does this PR do?

chore: remove link to https://github.com/rhdh-bot/openshift-helm-charts as it's deprecated / dead; new CI process uses quay.io/rhdh/chart, which is mentioned in the readme already (RHIDP-7643)

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

## Summary by Sourcery

Remove the dead RH DH bot Helm charts link from the Backstage Helm chart README and update the chart version to 3.2.6.

Enhancements:
- Bump Backstage Helm chart version to 3.2.6

Documentation:
- Remove deprecated rhdh-bot/openshift-helm-charts link from README