### PR TITLE
chore: Trigger the chart releaser workflow on both main and release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-1.[0-9]+
     paths:
       - "charts/**"
 
@@ -36,5 +37,6 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           config: cr.yaml
+          mark_as_latest: ${{ github.ref == 'refs/heads/main' }}
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,1 @@
 generate-release-notes: true
-


### PR DESCRIPTION
## Description of the change

This makes it easier to test upstream releases of the chart

## Which issue(s) does this PR fix or relate to

&mdash;

## How to test changes / Special notes to the reviewer

Tests done in https://github.com/rm3l/rhdh-chart/releases

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Extend the Helm chart releaser workflow to run on release branches as well as main, conditionally mark the main branch release as latest, and tidy up the releaser config file.

CI:
- Trigger the chart-releaser workflow on branch patterns matching release-1.* in addition to main
- Pass a mark_as_latest flag to the chart-releaser action only when running on main

Chores:
- Remove an extraneous blank line from cr.yaml