### PR TITLE
[release-1.7] fix: Add test case deploying an Orchestrator-flavored instance with a user provided npmrc secret [RHDHBUGS-1893] (#195)

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.4.2
+version: 4.4.3

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 4.4.2](https://img.shields.io/badge/Version-4.4.2-informational?style=flat-square)
+![Version: 4.4.3](https://img.shields.io/badge/Version-4.4.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -209,11 +209,12 @@ Kubernetes: `>= 1.27.0-0`
 | route.tls.key | Key file contents | string | `""` |
 | route.tls.termination | Specify TLS termination. | string | `"edge"` |
 | route.wildcardPolicy | Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed. | string | `"None"` |
-| test | Test pod parameters | object | `{"enabled":true,"image":{"registry":"quay.io","repository":"curl/curl","tag":"latest"}}` |
+| test | Test pod parameters | object | `{"enabled":true,"image":{"registry":"quay.io","repository":"curl/curl","tag":"latest"},"injectTestNpmrcSecret":false}` |
 | test.enabled | Whether to enable the test-connection pod used for testing the Release using `helm test`. | bool | `true` |
 | test.image.registry | Test connection pod image registry | string | `"quay.io"` |
 | test.image.repository | Test connection pod image repository. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"curl/curl"` |
 | test.image.tag | Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"latest"` |
+| test.injectTestNpmrcSecret | Whether to inject a fake dynamic plugins npmrc secret. <br />See RHDHBUGS-1893 and RHDHBUGS-1464 for the motivation behind this. <br />This is only used for testing purposes and should not be used in production. <br />Only relevant when `test.enabled` field is set to `true`. | bool | `false` |
 | upstream | Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml) | object | Use Openshift compatible settings |
 | upstream.backstage.extraVolumes[0] | Ephemeral volume that will contain the dynamic plugins installed by the initContainer below at start. | object | `{"ephemeral":{"volumeClaimTemplate":{"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}}}}},"name":"dynamic-plugins-root"}` |
 | upstream.backstage.extraVolumes[0].ephemeral.volumeClaimTemplate.spec.resources.requests.storage | Size of the volume that will contain the dynamic plugins. It should be large enough to contain all the plugins. | string | `"5Gi"` |

--- a/charts/backstage/ci/with-orchestrator-and-dynamic-plugins-npmrc-values.yaml
+++ b/charts/backstage/ci/with-orchestrator-and-dynamic-plugins-npmrc-values.yaml
@@ -1,0 +1,23 @@
+route:
+  enabled: false
+
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+global:
+  dynamic:
+    plugins:
+      # Enable additional plugins, which should be merged with the Orchestrator plugins
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+        disabled: false
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+        disabled: false
+
+orchestrator:
+  enabled: true
+
+test:
+  injectTestNpmrcSecret: true

--- a/charts/backstage/templates/tests/test-secret.yaml
+++ b/charts/backstage/templates/tests/test-secret.yaml
@@ -1,0 +1,16 @@
+# RHDHBUGS-1893: test-only option to inject a user-provided dynamic plugins npmrc secret.
+# Doing it this way because the secret name is dynamic and depends on the release name.
+{{- if and .Values.test.enabled .Values.test.injectTestNpmrcSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ .Release.Name }}-dynamic-plugins-npmrc'
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+immutable: true
+stringData:
+  .npmrc: |
+    @myscope:registry=https://my-registry.example.com
+    //my-registry.example.com:_authToken=foo
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -361,6 +361,45 @@
             "title": "OpenShift Route parameters.",
             "type": "object"
         },
+        "test": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "default": true,
+                    "title": "Enable test configuration. If enabled, test resources will be created to verify the Helm Release has been successfully deployed using the `helm test` command.",
+                    "type": "boolean"
+                },
+                "image": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "registry": {
+                            "default": "quay.io",
+                            "title": "Registry to use for the test pod image.",
+                            "type": "string"
+                        },
+                        "repository": {
+                            "default": "curl/curl",
+                            "title": "Repository to use for the test pod image.",
+                            "type": "string"
+                        },
+                        "tag": {
+                            "default": "latest",
+                            "title": "Tag to use for the test pod image.",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Image to use for the test pod. Note that the image needs to have both the `sh` and `curl` binaries in it.",
+                    "type": "object"
+                },
+                "injectTestNpmrcSecret": {
+                    "default": false,
+                    "title": "Whether to inject a fake dynamic plugins npmrc secret. This is only used for testing purposes and should not be used in production. It is only relevant when `test.enabled` field is set to `true`.",
+                    "type": "boolean"
+                }
+            },
+            "title": "Test configuration for the Backstage chart.",
+            "type": "object"
+        },
         "upstream": {
             "properties": {
                 "backstage": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -196,6 +196,45 @@
                 }
             }
         },
+        "test": {
+            "title": "Test configuration for the Backstage chart.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enable test configuration. If enabled, test resources will be created to verify the Helm Release has been successfully deployed using the `helm test` command.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "image": {
+                    "title": "Image to use for the test pod. Note that the image needs to have both the `sh` and `curl` binaries in it.",
+                    "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "registry": {
+                                "title": "Registry to use for the test pod image.",
+                                "type": "string",
+                                "default": "quay.io"
+                            },
+                            "repository": {
+                                "title": "Repository to use for the test pod image.",
+                                "type": "string",
+                                "default": "curl/curl"
+                            },
+                            "tag": {
+                                "title": "Tag to use for the test pod image.",
+                                "type": "string",
+                                "default": "latest"
+                            }
+                        }
+                },
+                "injectTestNpmrcSecret": {
+                    "title": "Whether to inject a fake dynamic plugins npmrc secret. This is only used for testing purposes and should not be used in production. It is only relevant when `test.enabled` field is set to `true`.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
         "orchestrator": {
             "title": "orchestrator configuration",
             "type": "object",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -349,6 +349,12 @@ test:
     # -- Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it.
     tag: latest
 
+  # -- Whether to inject a fake dynamic plugins npmrc secret.
+  # <br />See RHDHBUGS-1893 and RHDHBUGS-1464 for the motivation behind this.
+  # <br />This is only used for testing purposes and should not be used in production.
+  # <br />Only relevant when `test.enabled` field is set to `true`.
+  injectTestNpmrcSecret: false
+
 orchestrator:
   enabled: false
   serverlessLogicOperator:


### PR DESCRIPTION
## Description of the change

Manual cherry-pick of https://github.com/redhat-developer/rhdh-chart/pull/195#issuecomment-3097051006

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

Fixes https://issues.redhat.com/browse/RHDHBUGS-1893

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Enable injecting a user-provided .npmrc secret for dynamic plugins in helm test workflows and update chart version and documentation accordingly

Enhancements:
- Add injectTestNpmrcSecret flag in values.yaml to toggle injecting a fake dynamic plugins npmrc secret during helm tests
- Provide a new test-secret.yaml Helm hook template to generate a dynamic plugins .npmrc Secret in pre-install and pre-upgrade hooks when testing
- Introduce a CI-specific values file that enables orchestrator mode, dynamic plugins, and npmrc injection for automated test deployments

Documentation:
- Update README.md badge and document the new injectTestNpmrcSecret option

Chores:
- Bump backstage chart version to 4.4.3