### PR TITLE
Orchestrator-software-templates chart: Post-RHDH install resources

### DIFF
--- a/charts/orchestrator-software-templates-infra/README.md
+++ b/charts/orchestrator-software-templates-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Software Templates Infra Chart for OpenShift (Community Version)
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to install Openshift GitOps and Openshift Pipelines, which are required operators for installing the Orchestrator Software Templates to be available on RHDH.
@@ -119,7 +119,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | openshiftGitops.initialApps | Initial applications to deploy | list | `[]` |
 | openshiftGitops.initialRepositories | Initial repositories configuration | list | `[]` |
 | openshiftGitops.name | name of instances | string | `"argocd"` |
-| openshiftGitops.namespaces | namespace of rhdh instance, will be used to install openshift-gitops. | list | `["rhdh"]` |
+| openshiftGitops.namespaces | namespace of rhdh instance, will be used to install openshift-gitops. | list | `["orchestrator-gitops"]` |
 | openshiftGitops.repositoryCredentials | Repository credential templates | list | `[]` |
 | openshiftGitops.secrets | Secrets for Git access or other repository credentials | list | `[]` |
 | openshiftGitops.subscription | subscription config | object | `{"namespace":"openshift-operators","spec":{"channel":"latest","disableDefaultArgoCD":true,"installPlanApproval":"Automatic","name":"openshift-gitops-operator","source":"redhat-operators","sourceNamespace":"openshift-marketplace"}}` |

--- a/charts/orchestrator-software-templates-infra/ci/upstream-values.yaml
+++ b/charts/orchestrator-software-templates-infra/ci/upstream-values.yaml
@@ -12,7 +12,7 @@ openshiftPipelines:
 openshiftGitops:
   name: argocd
   namespaces:
-    - olm
+    - orchestrator-gitops
   subscription:
     namespace: operators
     name: argocd-operator

--- a/charts/orchestrator-software-templates-infra/templates/NOTES.txt
+++ b/charts/orchestrator-software-templates-infra/templates/NOTES.txt
@@ -46,5 +46,5 @@ oc wait --for=condition=Ready pod --all -n openshift-pipelines --timeout=120s
 Run the following command to validate that the openshift-gitops namespace and all pods within it are operational:
 
 oc wait --for=jsonpath='{.status.phase}'=Active namespace/openshift-gitops --timeout=80s && \
-oc wait --for=condition=Ready pod --all -n {{ .Release.Namespace }} --timeout=120s
+oc wait --for=condition=Ready pod --all -n orchestrator-gitops --timeout=120s
 {{- end }}

--- a/charts/orchestrator-software-templates-infra/templates/catalogsource.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/catalogsource.yaml
@@ -1,6 +1,6 @@
-{{- $pipelinesEnabled := .Values.openshiftPipelines.enabled }}
-{{- $gitopsEnabled := .Values.openshiftGitops.enabled }}
-{{- $shouldCreate := or $pipelinesEnabled $gitopsEnabled }}
+{{- $pipelinesUsesOperatorHub := and .Values.openshiftPipelines.enabled (eq .Values.openshiftPipelines.subscription.spec.source "operatorhubio-catalog") }}
+{{- $gitopsUsesOperatorHub := and .Values.openshiftGitops.enabled (eq .Values.openshiftGitops.subscription.spec.source "operatorhubio-catalog") }}
+{{- $shouldCreate := or $pipelinesUsesOperatorHub $gitopsUsesOperatorHub }}
 
 
 {{- if $shouldCreate }}
@@ -11,6 +11,10 @@ kind: CatalogSource
 metadata:
   name: operatorhubio-catalog
   namespace: olm
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-8"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   sourceType: grpc
   image: quay.io/operator-framework/upstream-community-operators:latest

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrole.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrole.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/name: {{ .Values.openshiftGitops.namespaces | first }}-argocd-application-controller
     app.kubernetes.io/part-of: {{ .Values.openshiftGitops.namespaces | first }}
   name: {{ .Values.openshiftGitops.namespaces | first }}-argocd-application-controller
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrolebinding.yaml
@@ -9,7 +9,9 @@ metadata:
     app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
     app.kubernetes.io/part-of: {{ $.Values.openshiftGitops.namespaces | first }}
   annotations:
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
   name: {{ $ns }}-argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-cr.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-cr.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.openshiftGitops.namespaces (.Capabilities.APIVersions.Has "argoproj.io/v1beta1/ArgoCD") }}
 {{- range $ns := .Values.openshiftGitops.namespaces }}
+{{- if ne $ns "openshift-gitops" }}
 ---
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
@@ -8,10 +9,14 @@ metadata:
   labels:
     app: {{ $.Values.openshiftGitops.name }}
   namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
 spec:
   applicationInstanceLabelKey: rht-gitops.com/{{ $ns }}
   {{- if $.Values.openshiftGitops.argocd_cr }}
   {{- $.Values.openshiftGitops.argocd_cr | toYaml | trim | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-credential-template.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-credential-template.yaml
@@ -7,6 +7,10 @@ kind: Secret
 metadata:
   name: {{ $cred.name }}
   namespace: {{ $ns }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     argocd.argoproj.io/secret-type: repo-creds
 stringData:

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-initial-apps.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-initial-apps.yaml
@@ -7,6 +7,9 @@ kind: Application
 metadata:
   name: {{ $app.name }}
   namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
 spec:
   destination:
     namespace: {{ $ns }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-initial-repositories.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-initial-repositories.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: {{ $ns }}
   labels:
     argocd.argoproj.io/secret-type: repository
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
 stringData:
   type: {{ $repo.type }}
   url: {{ $repo.url }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-server-clusterrole.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-server-clusterrole.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/name: {{ .Values.openshiftGitops.namespaces | first }}-gitops-argocd-server
     app.kubernetes.io/part-of: {{ .Values.openshiftGitops.namespaces | first }}
   name: {{ .Values.openshiftGitops.namespaces | first }}-gitops-argocd-server
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
   - apiGroups: [""]
     resources: ["pods", "logs"]

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-server-clusterrolebinding.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-server-clusterrolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/name: {{ $ns }}-argocd-server
     app.kubernetes.io/part-of: {{ $ns }}
   name: {{ $ns }}-argocd-server
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/crd-reader.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/crd-reader.yaml
@@ -4,8 +4,8 @@ metadata:
   name: crd-reader
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -22,8 +22,8 @@ metadata:
   name: crd-reader-binding
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/namespace.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/namespace.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.openshiftGitops.namespaces }}
 {{- range $index, $ns := .Values.openshiftGitops.namespaces }}
-{{- if ne $index 0 }}
+{{- if ne $ns "openshift-gitops" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -9,6 +9,7 @@ metadata:
     "openshift.io/description": ""
     "openshift.io/display-name": ""
     "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
   labels:
     kubernetes.io/metadata.name: {{ $ns }}
     openshift.io/cluster-monitoring: "true"

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/namespace.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/namespace.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.openshiftGitops.namespaces }}
 {{- range $index, $ns := .Values.openshiftGitops.namespaces }}
-{{- if ne $ns "openshift-gitops" }}
+{{- if and (ne $ns "openshift-gitops") (ne $ns "olm") }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/post-cleanup.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/post-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openshiftGitops.enabled }}
+{{- if .Values.openshiftGitops.enabled }}
 
 apiVersion: v1
 kind: ServiceAccount
@@ -17,24 +17,15 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "10"
 rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "delete"]
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "subscriptions"]
-    verbs: ["get", "list", "delete", "watch"]
-  - apiGroups: ["apps", ""]
-    resources: ["deployments", "pods"]
-    verbs: ["get", "list", "delete"]
-  - apiGroups: [""]
-    resources: ["pods", "services", "namespaces"]
-    verbs: ["get", "list", "delete"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles", "clusterrolebindings"]
-    verbs: ["get", "list", "delete"]
+    verbs: ["get", "list", "delete", "watch", "patch", "update"]
   - apiGroups: ["argoproj.io"]
-    resources: ["applications", "appprojects", "argocds", "argocd"]
-    verbs: ["get", "list", "watch", "delete"]
+    resources: ["argocds", "applications", "appprojects"]
+    verbs: ["get", "list", "delete", "watch", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -55,7 +46,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: openshift-gitops-cleanup-gitops
+  name: openshift-gitops-cleanup
   namespace: {{ .Values.openshiftGitops.subscription.namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -67,8 +58,17 @@ spec:
       serviceAccountName: csv-cleanup-gitops
       restartPolicy: Never
       containers:
-      - name: cleanup
+      - name: cleanup-gitops
         image: {{ .Values.cleanupContainerImage }}
+        env:
+          - name: NAMESPACE
+            value: {{ .Values.openshiftGitops.subscription.namespace }}
+          - name: NAME
+            value: {{ .Values.openshiftGitops.subscription.spec.name }}
+          - name: ARGOCD_NAME
+            value: {{ .Values.openshiftGitops.name }}
+          - name: ARGOCD_NAMESPACES
+            value: {{ join "," .Values.openshiftGitops.namespaces }}
         resources:
           requests:
             memory: {{ .Values.resources.requests.memory }}
@@ -76,11 +76,6 @@ spec:
           limits:
             memory: {{ .Values.resources.limits.memory }}
             cpu: {{ .Values.resources.limits.cpu }}
-        env:
-          - name: NAMESPACE
-            value: {{ .Values.openshiftGitops.subscription.namespace }}
-          - name: NAME
-            value: {{ .Values.openshiftGitops.subscription.spec.name }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -93,137 +88,51 @@ spec:
         - /bin/sh
         - -c
         - |
-          set +e # Continue on error
+          set +e
 
-          echo "Starting OpenShift GitOps Cleanup Job..."
+          echo "Waiting for Subscription to be deleted..."
+          kubectl delete subscription.operators.coreos.com $NAME -n $NAMESPACE --ignore-not-found
+          kubectl wait --for=delete subscription.operators.coreos.com/$NAME -n $NAMESPACE --timeout=30s || echo "Subscription deletion timed out, continuing..."
 
-          # --- Phase 1: Delete OpenShift GitOps Operator Subscription FIRST ---
-          echo "Phase 1: Deleting OpenShift GitOps Operator Subscription to stop operator reconciliation..."
-          
-          echo "Attempting to delete Subscription $NAME in $NAMESPACE..."
-          kubectl delete subscription $NAME -n $NAMESPACE --ignore-not-found
-          echo "Waiting for Subscription to be deleted (timeout 90s)..."
-          kubectl wait --for=delete subscription/$NAME -n $NAMESPACE --timeout=90s || echo "Subscription deletion timed out or resource not found, continuing..."
-          
-          # Give the operator time to stop reconciling
-          echo "Waiting 10 seconds for operator to stop reconciling..."
-          sleep 10
-          
-          echo "Phase 1: Subscription deletion complete."
-          echo ""
+          echo "Waiting for CSV to be deleted..."
+          kubectl delete csv -l operators.coreos.com/$NAME.$NAMESPACE='' -n $NAMESPACE --ignore-not-found
+          kubectl wait --for=delete csv -l operators.coreos.com/$NAME.$NAMESPACE='' -n $NAMESPACE --timeout=60s || echo "CSV deletion timed out, continuing..."
 
-          # --- Phase 2: Delete all Applications ---
-          echo "Phase 2: Deleting all Application resources across all namespaces..."
-          
-          # Get unique list of namespaces that contain Applications
-          namespaces_with_apps=$(kubectl get applications.argoproj.io -A -o custom-columns="NAMESPACE:.metadata.namespace" --no-headers 2>/dev/null | sort -u)
-
-          if [ -z "$namespaces_with_apps" ]; then
-            echo "No Application resources found. Skipping Application deletion."
-          else
-            echo "$namespaces_with_apps" | while read -r ns; do
-              echo "  Processing namespace: $ns for Applications"
-              # Get all Applications in the current namespace
-              applications_in_ns=$(kubectl get applications.argoproj.io -n "$ns" -o custom-columns="NAME:.metadata.name" --no-headers 2>/dev/null)
-
-              if [ -z "$applications_in_ns" ]; then
-                echo "    No Applications found in $ns."
-              else
-                echo "$applications_in_ns" | while read -r app; do
-                  if [ -n "$app" ]; then
-                    echo "    Deleting Application: $app in namespace: $ns"
-                    kubectl delete applications.argoproj.io "$app" -n "$ns" --ignore-not-found
-                  fi
-                done
-              fi
-            done
-          fi
-          echo "Phase 2: Application deletion complete."
-          echo ""
-
-          # --- Phase 3: Delete all AppProjects ---
-          echo "Phase 3: Deleting all AppProject resources across all namespaces..."
-          
-          # Get unique list of namespaces that contain AppProjects
-          namespaces_with_appprojects=$(kubectl get appprojects.argoproj.io -A -o custom-columns="NAMESPACE:.metadata.namespace" --no-headers 2>/dev/null | sort -u)
-
-          if [ -z "$namespaces_with_appprojects" ]; then
-            echo "No AppProject resources found. Skipping AppProject deletion."
-          else
-            echo "$namespaces_with_appprojects" | while read -r ns; do
-              echo "  Processing namespace: $ns for AppProjects"
-              # Get all AppProjects in the current namespace
-              appprojects_in_ns=$(kubectl get appprojects.argoproj.io -n "$ns" -o custom-columns="NAME:.metadata.name" --no-headers 2>/dev/null)
-
-              if [ -z "$appprojects_in_ns" ]; then
-                echo "    No AppProjects found in $ns."
-              else
-                echo "$appprojects_in_ns" | while read -r proj; do
-                  if [ -n "$proj" ]; then
-                    echo "    Deleting AppProject: $proj in namespace: $ns"
-                    kubectl delete appprojects.argoproj.io "$proj" -n "$ns" --ignore-not-found
-                  fi
-                done
-              fi
-            done
-          fi
-          echo "Phase 3: AppProject deletion complete."
-          echo ""
-
-          # --- Phase 4: Delete all ArgoCD instances ---
-          echo "Phase 4: Deleting all ArgoCD instances across all namespaces..."
-
-          # Get a list of all ArgoCD instances (namespace and name) once
-          argo_instances=$(kubectl get argocd -A -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" --no-headers 2>/dev/null)
-
-          if [ -z "$argo_instances" ]; then
-            echo "No ArgoCD instances found. Skipping ArgoCD instance deletion."
-          else
-            echo "$argo_instances" | while read -r ns argo_name; do
-              if [ -n "$ns" ] && [ -n "$argo_name" ]; then
-                echo "  Attempting to delete ArgoCD instance '$argo_name' in namespace: $ns"
-                # First, try a regular delete. If it gets stuck (due to finalizers),
-                # we will attempt to patch.
-                kubectl delete argocd "$argo_name" -n "$ns" --ignore-not-found --timeout=30s
+          echo "Finding and cleaning up all ArgoCD resources..."
+          # Get all ArgoCD resources across all namespaces
+          kubectl get argocd --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' | while read -r ns name; do
+            if [ -n "$ns" ] && [ -n "$name" ]; then
+              echo "  - Found ArgoCD $name in namespace $ns"
+              
+              # Try normal deletion first
+              kubectl delete argocd $name -n $ns --ignore-not-found --timeout=15s 2>/dev/null || true
+              
+              # Check if still exists (likely stuck with finalizers)
+              if kubectl get argocd $name -n $ns >/dev/null 2>&1; then
+                echo "    ArgoCD $name stuck, removing finalizers..."
                 
-                # Check if the ArgoCD instance is still present (meaning it's stuck with a finalizer)
-                if kubectl get argocd "$argo_name" -n "$ns" &>/dev/null; then
-                  echo "  ArgoCD instance '$argo_name' in namespace '$ns' is stuck. Attempting to remove finalizers."
-                  # Patch the resource to remove finalizers
-                  kubectl patch argocd "$argo_name" -n "$ns" --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]' || \
-                    echo "    Warning: Failed to patch finalizers for $argo_name in $ns. It might remain."
-                  echo "  Re-attempting delete for ArgoCD instance '$argo_name' in namespace: $ns after finalizer removal."
-                  kubectl delete argocd "$argo_name" -n "$ns" --ignore-not-found --timeout=30s
-                fi
+                # Remove finalizers using JSON patch
+                kubectl patch argocd $name -n $ns --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
+                
+                # Force delete
+                kubectl delete argocd $name -n $ns --force --grace-period=0 2>/dev/null || true
+                
+                echo "    ArgoCD $name force deleted"
+              else
+                echo "    ArgoCD $name deleted successfully"
               fi
-            done
-          fi
-          echo "Phase 4: ArgoCD instance deletion complete."
-          echo ""
+            fi
+          done
 
-          # --- Phase 5: Delete ClusterServiceVersion (CSV) ---
-          echo "Phase 5: Deleting ClusterServiceVersion (CSV) for $NAME in $NAMESPACE..."
-          
-          # Find CSVs that match the operator name pattern
-          csv_names=$(kubectl get csv -n $NAMESPACE -o name | grep -E "(gitops|argocd)" 2>/dev/null || echo "")
-          
-          if [ -z "$csv_names" ]; then
-            echo "No GitOps/ArgoCD CSVs found in $NAMESPACE."
-          else
-            echo "$csv_names" | while read -r csv_name; do
-              if [ -n "$csv_name" ]; then
-                echo "  Deleting CSV: $csv_name"
-                kubectl delete "$csv_name" -n $NAMESPACE --ignore-not-found
-              fi
-            done
-          fi
-          
-          echo "Waiting for CSV to be deleted (timeout 120s)..."
-          kubectl wait --for=delete csv -l operators.coreos.com/$NAME.$NAMESPACE='' -n $NAMESPACE --timeout=120s 2>/dev/null || echo "CSV deletion wait timed out or resource not found, continuing..."
+          echo "Cleaning up AppProjects and Applications in managed namespaces..."
+          echo "$ARGOCD_NAMESPACES" | tr ',' '\n' | while read -r ns; do
+            if [ -n "$ns" ]; then
+              echo "  - Cleaning namespace $ns"
+              kubectl delete appproject default -n $ns --ignore-not-found --timeout=15s 2>/dev/null || true
+              kubectl delete application -l app.kubernetes.io/managed-by=Helm -n $ns --ignore-not-found --timeout=15s 2>/dev/null || true
+            fi
+          done
 
-          echo "Phase 5: CSV deletion complete."
-          echo ""
+          echo "Cleanup finished."
 
-          echo "OpenShift GitOps cleanup job finished successfully."
-        
 {{- end }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/secrets.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/secrets.yaml
@@ -7,6 +7,10 @@ kind: Secret
 metadata:
   name: {{ $secret.name }}
   namespace: {{ $ns }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/part-of: argocd

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/subscription.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/subscription.yaml
@@ -5,6 +5,9 @@ kind: Subscription
 metadata:
   name: {{ .Values.openshiftGitops.subscription.spec.name }}
   namespace: {{ .Values.openshiftGitops.subscription.namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
 spec:
   channel: {{ .Values.openshiftGitops.subscription.spec.channel }}
   installPlanApproval: {{ .Values.openshiftGitops.subscription.installPlanApproval }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-pipelines/subscription.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-pipelines/subscription.yaml
@@ -6,6 +6,9 @@ kind: Subscription
 metadata:
   name: {{ .Values.openshiftPipelines.subscription.name }}
   namespace: {{ .Values.openshiftPipelines.subscription.namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
 spec:
   channel: {{ .Values.openshiftPipelines.subscription.spec.channel }}
   installPlanApproval: {{ .Values.openshiftPipelines.subscription.spec.installPlanApproval }}

--- a/charts/orchestrator-software-templates-infra/values.yaml
+++ b/charts/orchestrator-software-templates-infra/values.yaml
@@ -26,7 +26,7 @@ openshiftGitops:
 
   # -- namespace of rhdh instance, will be used to install openshift-gitops.
   namespaces:
-    - rhdh
+    - orchestrator-gitops
 
   # -- subscription config
   subscription:

--- a/charts/orchestrator-software-templates/.helmignore
+++ b/charts/orchestrator-software-templates/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/orchestrator-software-templates/Chart.yaml
+++ b/charts/orchestrator-software-templates/Chart.yaml
@@ -3,14 +3,15 @@ annotations:
   charts.openshift.io/provider: Red Hat Developer Hub Team
   charts.openshift.io/supportURL: https://issues.redhat.com/browse/RHIDP
 apiVersion: v2
-name: orchestrator-software-templates-infra
+name: orchestrator-software-templates
 description: >
-  A Helm chart to install Openshift GitOps and Openshift Pipelines, which are required operators for installing the Orchestrator Software Templates to be available on RHDH.
+  This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH) and other necessary GitOps configurations.
+
 kubeVersion: ">= 1.25.0-0"
 type: application
 sources:
-  - https://github.com/redhat-developer/rhdh-software-templates-infrastructure
-version: 0.2.2
+  - https://github.com/redhat-developer/rhdh-chart
+version: 0.1.0
 maintainers:
   - name: Red Hat Developer Hub Team
     url: https://github.com/redhat-developer/rhdh-chart

--- a/charts/orchestrator-software-templates/README.md
+++ b/charts/orchestrator-software-templates/README.md
@@ -1,0 +1,157 @@
+
+# Orchestrator Software Templates Chart for Red Hat Developer Hub
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH) and other necessary GitOps configurations.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Red Hat Developer Hub Team |  | <https://github.com/redhat-developer/rhdh-chart> |
+
+## Source Code
+
+* <https://github.com/redhat-developer/rhdh-chart>
+
+## Requirements
+
+Kubernetes: `>= 1.25.0-0`
+
+## Overview
+
+This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH). It creates the necessary configurations and resources to enable orchestrator functionality within RHDH, including:
+
+- Software template configurations for RHDH integration
+- Tekton pipelines and tasks for workflow orchestration
+- ArgoCD project configurations for GitOps workflows
+- Authentication and catalog configurations for various SCM providers (GitHub, GitLab)
+
+## Prerequisites
+
+Before installing this chart, ensure you have installed the following:
+
+0. Orchestrator-infra chart: responsible for installing necessary resources for Orchestrator to work.
+1. Backstage chart: responsible for **Red Hat Developer Hub** and Orchestrator. It should be deployed and configured with Orchestrator enabled.
+2. Orchestrator-software-templates-infra chart: responsible for deploying **OpenShift Pipelines** (Tekton) operator and **OpenShift GitOps** (ArgoCD) operator. It should be deployed in the same namespace as the backstage chart.
+3. Running the setup script: responsible for creating the required secret for the software templates chart.
+4. Optional: To make full use of ArgoCD and Tekton, you must following the instruction to configure the docker secret and ssh credentials, here: https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md.
+5. Label the RHDH namespace with `oc label ns rhdh rhdh.redhat.com/argocd-namespace=true` to enable the configuration sync.
+
+The chart requires a secret named `orchestrator-auth-secret` in the RHDH namespace containing the following keys:
+
+- `BACKEND_SECRET`: Backend authentication secret
+- `K8S_CLUSTER_TOKEN`: Kubernetes cluster token
+- `K8S_CLUSTER_URL`: Kubernetes cluster URL
+- `GITHUB_TOKEN`: GitHub access token (optional)
+- `GITHUB_CLIENT_ID`: GitHub OAuth client ID (optional)
+- `GITHUB_CLIENT_SECRET`: GitHub OAuth client secret (optional)
+- `GITLAB_HOST`: GitLab host URL (optional)
+- `GITLAB_TOKEN`: GitLab access token (optional)
+- `ARGOCD_URL`: ArgoCD server URL (optional)
+- `ARGOCD_USERNAME`: ArgoCD username (optional)
+- `ARGOCD_PASSWORD`: ArgoCD password (optional)
+
+Acquire the following ArgoCD:
+
+ARGOCD_URL: https://argocd-server.<apps.example.com>
+ARGOCD_USERNAME: admin
+ARGOCD_PASSWORD: `oc get secret -n openshift-gitops openshift-gitops-cluster -o jsonpath='{.data.admin\.password}' | base64 -d`
+
+The secret can be created by the setup script or manually
+
+```bash
+oc create secret generic orchestrator-auth-secret \
+  -n rhdh \
+  --from-literal=BACKEND_SECRET=your-backend-secret \
+  --from-literal=K8S_CLUSTER_TOKEN=your-k8s-token \
+  --from-literal=K8S_CLUSTER_URL=https://your-cluster-url \
+  --from-literal=GITHUB_TOKEN=your-github-token
+```
+
+## Installation
+
+After configuring all prerequisites, you can install the chart with the following command:
+
+```console
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install my-orchestrator-templates redhat-developer/orchestrator-software-templates
+```
+
+Now, follow the instruction on the post-installation Notes. They will include the steps to create a custom values.yaml file to allow you to update the backstage chart
+
+## Running a template
+
+In the RHDH UI, you will now have some software templates available. You can select one and click on "Run" to start the workflow.
+For example, you can run the "Github Basic workflow bootstrap project" template to create a new workflow project.
+After bootstrapping the project, a Tekton pipeline will build and push the workflow, and the ArgoCD project we have configured will deploy it onto the cluster in the rhdh namespace.
+After all GitOps components run successfully, you can now run the workflow via Orchestrator.
+
+## Uninstalling the Chart
+
+To uninstall/delete a Helm release named `orchestrator-templates`:
+
+```console
+helm uninstall my-orchestrator-templates
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Secret not found error**: Ensure the `orchestrator-auth-secret` exists in the correct namespace
+2. **CRD not available**: Verify that Tekton and ArgoCD operators are installed and their CRDs are available
+3. **RHDH not picking up configurations**: Check that the ConfigMaps have the correct label `rhdh.redhat.com/ext-config-sync: "true"`
+4. **Tekton PipelineRuns are not successful**: Make sure that affinity-assistant is disabled in the TektonConfig CR. To disable it, edit the tekton config and make sure the `coschedule` feature flag is set to `false`
+5. **Namespace labeling**: Label the RHDH namespace for ArgoCD management: `oc label ns rhdh argocd.argoproj.io/managed-by=orchestrator-gitops`
+6. **Bootstrap project permissions**: When running templates to create bootstrap projects, ensure the bootstrap project repository has write permissions. You can change the permissions by editing the repository in Github.
+7. **AppProject creation**: If no AppProject exists, create a new AppProject in the `orchestrator-gitops` namespace
+8. **Required secrets**: Ensure the docker merged secret and orchestrator auth secret are present on the cluster
+9. **Concurrent pipeline runs**: Avoid running multiple pipelines simultaneously - if a pipeline fails, ensure no other pipelines are running at the same time
+10. **GitOps pipeline flow**: Follow the complete workflow: PipelineRun → GitOps pipeline → Workflow deployment on cluster
+
+### Checking Prerequisites
+
+The chart will validate that required CRDs are available:
+- `tekton.dev/v1/Task`
+- `tekton.dev/v1/Pipeline`
+- `argoproj.io/v1alpha1/AppProject`
+
+Check the Helm release notes after installation for any warnings about missing CRDs.
+
+## Values
+
+| Key | Description | Type | Default |
+|-----|-------------|------|---------|
+| argocd.argocdNamespace | References the ArgoCD instance created by infra chart | string | `"orchestrator-gitops"` |
+| argocd.enabled |  | bool | `true` |
+| orchestratorTemplates.enabled |  | bool | `true` |
+| orchestratorTemplates.rhdhChartNamespace |  | string | `"rhdh"` |
+| orchestratorTemplates.rhdhChartReleaseName |  | string | `"rhdh"` |
+| rhdhConfig.catalogBranch | Branch to use for catalog templates | string | `"main"` |
+| rhdhConfig.enableGuestProvider | Enable guest authentication provider | bool | `false` |
+| rhdhConfig.enabled | Enable RHDH operator | bool | `true` |
+| rhdhConfig.secretRef.argocd.password | Key in the secret for ArgoCD password | string | `"ARGOCD_PASSWORD"` |
+| rhdhConfig.secretRef.argocd.url | Key in the secret for ArgoCD URL | string | `"ARGOCD_URL"` |
+| rhdhConfig.secretRef.argocd.username | Key in the secret for ArgoCD username | string | `"ARGOCD_USERNAME"` |
+| rhdhConfig.secretRef.backstage.backendSecret | Key in the secret for backend authentication | string | `"BACKEND_SECRET"` |
+| rhdhConfig.secretRef.github.clientId | Key in the secret for GitHub client ID | string | `"GITHUB_CLIENT_ID"` |
+| rhdhConfig.secretRef.github.clientSecret | Key in the secret for GitHub client secret | string | `"GITHUB_CLIENT_SECRET"` |
+| rhdhConfig.secretRef.github.token | Key in the secret for GitHub token | string | `"GITHUB_TOKEN"` |
+| rhdhConfig.secretRef.gitlab.host | Key in the secret for GitLab host | string | `"GITLAB_HOST"` |
+| rhdhConfig.secretRef.gitlab.token | Key in the secret for GitLab token | string | `"GITLAB_TOKEN"` |
+| rhdhConfig.secretRef.k8s.clusterToken | Key in the secret for Kubernetes cluster token | string | `"K8S_CLUSTER_TOKEN"` |
+| rhdhConfig.secretRef.k8s.clusterUrl | Key in the secret for Kubernetes cluster URL | string | `"K8S_CLUSTER_URL"` |
+| rhdhConfig.secretRef.name | Name of the secret containing the configuration | string | `"orchestrator-auth-secret"` |
+| tekton.enabled |  | bool | `true` |
+
+## Additional Resources
+
+- [Red Hat Developer Hub Documentation](https://access.redhat.com/documentation/en-us/red_hat_developer_hub)
+- [OpenShift Pipelines Documentation](https://docs.openshift.com/container-platform/latest/cicd/pipelines/understanding-openshift-pipelines.html)
+- [OpenShift GitOps Documentation](https://docs.openshift.com/container-platform/latest/cicd/gitops/understanding-openshift-gitops.html)

--- a/charts/orchestrator-software-templates/README.md.gotmpl
+++ b/charts/orchestrator-software-templates/README.md.gotmpl
@@ -1,0 +1,130 @@
+# Orchestrator Software Templates Chart for Red Hat Developer Hub
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}
+{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Overview
+
+This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH). It creates the necessary configurations and resources to enable orchestrator functionality within RHDH, including:
+
+- Software template configurations for RHDH integration
+- Tekton pipelines and tasks for workflow orchestration
+- ArgoCD project configurations for GitOps workflows
+- Authentication and catalog configurations for various SCM providers (GitHub, GitLab)
+
+## Prerequisites
+
+Before installing this chart, ensure you have installed the following:
+
+0. Orchestrator-infra chart: responsible for installing necessary resources for Orchestrator to work.
+1. Backstage chart: responsible for **Red Hat Developer Hub** and Orchestrator. It should be deployed and configured with Orchestrator enabled. 
+2. Orchestrator-software-templates-infra chart: responsible for deploying **OpenShift Pipelines** (Tekton) operator and **OpenShift GitOps** (ArgoCD) operator. It should be deployed in the same namespace as the backstage chart.
+3. Running the setup script: responsible for creating the required secret for the software templates chart.
+4. Optional: To make full use of ArgoCD and Tekton, you must following the instruction to configure the docker secret and ssh credentials, here: https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md.
+5. Label the RHDH namespace with `oc label ns rhdh rhdh.redhat.com/argocd-namespace=true` to enable the configuration sync.
+
+
+The chart requires a secret named `orchestrator-auth-secret` in the RHDH namespace containing the following keys:
+
+- `BACKEND_SECRET`: Backend authentication secret
+- `K8S_CLUSTER_TOKEN`: Kubernetes cluster token
+- `K8S_CLUSTER_URL`: Kubernetes cluster URL
+- `GITHUB_TOKEN`: GitHub access token (optional)
+- `GITHUB_CLIENT_ID`: GitHub OAuth client ID (optional)
+- `GITHUB_CLIENT_SECRET`: GitHub OAuth client secret (optional)
+- `GITLAB_HOST`: GitLab host URL (optional)
+- `GITLAB_TOKEN`: GitLab access token (optional)
+- `ARGOCD_URL`: ArgoCD server URL (optional)
+- `ARGOCD_USERNAME`: ArgoCD username (optional)
+- `ARGOCD_PASSWORD`: ArgoCD password (optional)
+
+Acquire the following ArgoCD:
+
+ARGOCD_URL: https://argocd-server.<apps.example.com>
+ARGOCD_USERNAME: admin
+ARGOCD_PASSWORD: `oc get secret -n openshift-gitops openshift-gitops-cluster -o jsonpath='{.data.admin\.password}' | base64 -d`
+
+The secret can be created by the setup script or manually
+
+```bash
+oc create secret generic orchestrator-auth-secret \
+  -n rhdh \
+  --from-literal=BACKEND_SECRET=your-backend-secret \
+  --from-literal=K8S_CLUSTER_TOKEN=your-k8s-token \
+  --from-literal=K8S_CLUSTER_URL=https://your-cluster-url \
+  --from-literal=GITHUB_TOKEN=your-github-token
+```
+
+## Installation
+
+After configuring all prerequisites, you can install the chart with the following command:
+
+```console
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+
+helm install my-orchestrator-templates redhat-developer/orchestrator-software-templates
+```
+
+Now, follow the instruction on the post-installation Notes. They will include the steps to create a custom values.yaml file to allow you to update the backstage chart
+
+## Running a template
+
+In the RHDH UI, you will now have some software templates available. You can select one and click on "Run" to start the workflow.
+For example, you can run the "Github Basic workflow bootstrap project" template to create a new workflow project. 
+After bootstrapping the project, a Tekton pipeline will build and push the workflow, and the ArgoCD project we have configured will deploy it onto the cluster in the rhdh namespace.
+After all GitOps components run successfully, you can now run the workflow via Orchestrator.
+
+
+## Uninstalling the Chart
+
+To uninstall/delete a Helm release named `orchestrator-templates`:
+
+```console
+helm uninstall my-orchestrator-templates
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Secret not found error**: Ensure the `orchestrator-auth-secret` exists in the correct namespace
+2. **CRD not available**: Verify that Tekton and ArgoCD operators are installed and their CRDs are available
+3. **RHDH not picking up configurations**: Check that the ConfigMaps have the correct label `rhdh.redhat.com/ext-config-sync: "true"`
+4. **Tekton PipelineRuns are not successful**: Make sure that affinity-assistant is disabled in the TektonConfig CR. To disable it, edit the tekton config and make sure the `coschedule` feature flag is set to `false`
+5. **Namespace labeling**: Label the RHDH namespace for ArgoCD management: `oc label ns rhdh argocd.argoproj.io/managed-by=orchestrator-gitops`
+6. **Bootstrap project permissions**: When running templates to create bootstrap projects, ensure the bootstrap project repository has write permissions. You can change the permissions by editing the repository in Github.
+7. **AppProject creation**: If no AppProject exists, create a new AppProject in the `orchestrator-gitops` namespace
+8. **Required secrets**: Ensure the docker merged secret and orchestrator auth secret are present on the cluster
+9. **Concurrent pipeline runs**: Avoid running multiple pipelines simultaneously - if a pipeline fails, ensure no other pipelines are running at the same time
+10. **GitOps pipeline flow**: Follow the complete workflow: PipelineRun → GitOps pipeline → Workflow deployment on cluster
+
+### Checking Prerequisites
+
+The chart will validate that required CRDs are available:
+- `tekton.dev/v1/Task`
+- `tekton.dev/v1/Pipeline` 
+- `argoproj.io/v1alpha1/AppProject`
+
+Check the Helm release notes after installation for any warnings about missing CRDs.
+
+{{ template "chart.valuesSection" . }}
+
+## Additional Resources
+
+- [Red Hat Developer Hub Documentation](https://access.redhat.com/documentation/en-us/red_hat_developer_hub)
+- [OpenShift Pipelines Documentation](https://docs.openshift.com/container-platform/latest/cicd/pipelines/understanding-openshift-pipelines.html)
+- [OpenShift GitOps Documentation](https://docs.openshift.com/container-platform/latest/cicd/gitops/understanding-openshift-gitops.html)

--- a/charts/orchestrator-software-templates/ci/upstream-values.yaml
+++ b/charts/orchestrator-software-templates/ci/upstream-values.yaml
@@ -1,0 +1,15 @@
+argocd:
+  enabled: true
+  argocdNamespace: orchestrator-gitops
+
+tekton:
+  enabled: true
+
+rhdhConfig:
+  secretRef:
+    name: orchestrator-auth-secret
+    k8s:
+      clusterToken: fake-token-for-testing
+
+orchestratorTemplates:
+  enabled: true

--- a/charts/orchestrator-software-templates/orchestrator-templates-values.yaml.template
+++ b/charts/orchestrator-software-templates/orchestrator-templates-values.yaml.template
@@ -1,0 +1,211 @@
+# Template file for orchestrator templates values
+# This values file will be merged with the existing values in the backstage release.
+# 
+# INSTRUCTIONS FOR MANUAL EDITING:
+# 1. Replace __RHDH_BASE_URL__ with your actual RHDH route URL
+#    Example: https://rhdh-developer-hub-rhdh.apps.cluster-abc123.abc123.sandbox.opentlc.com
+# 2. Replace {{CLUSTER_DOMAIN}} with your cluster's domain (if needed)
+#    Example: apps.cluster-abc123.abc123.sandbox.opentlc.com
+# 3. Update any other environment-specific values as needed
+# 
+# AUTOMATED GENERATION:
+# You can also use sed to replace placeholders automatically:
+#   RHDH_ROUTE="https://$(oc get route -n your-rhdh-namespace -o jsonpath='{.items[0].spec.host}')"
+#   sed -i "s|__RHDH_BASE_URL__|$RHDH_ROUTE|g" this-file.yaml
+# 
+# VALIDATION:
+# After editing, verify that no __*__ placeholders remain:
+#   grep "__.*__" this-file.yaml
+
+# Configure dynamic plugins directly (no ConfigMap mounting needed)
+global:
+  dynamic:
+    includes:
+      - "dynamic-plugins.default.yaml"
+    plugins:
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+        pluginConfig:
+          kubernetes:
+            clusterLocatorMethods:
+              - type: config
+                clusters:
+                  - name: Default Cluster
+                    authProvider: serviceAccount
+                    url: https://kubernetes.default.svc
+                    skipTLSVerify: false
+            customResources:
+              - apiVersion: v1
+                group: tekton.dev
+                plural: pipelines
+              - apiVersion: v1
+                group: tekton.dev
+                plural: pipelineruns
+              - apiVersion: v1
+                group: tekton.dev
+                plural: taskruns
+              - apiVersion: v1
+                group: route.openshift.io
+                plural: routes
+            serviceLocatorMethod:
+              type: multiTenant
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+
+upstream:
+  backstage:
+    appConfig:
+      app:
+        baseUrl: __RHDH_BASE_URL__
+      auth:
+        environment: development
+        providers:
+          guest:
+            dangerouslyAllowOutsideDevelopment: true
+          github:
+            development:
+              clientId: ${GITHUB_CLIENT_ID}
+              clientSecret: ${GITHUB_CLIENT_SECRET}
+              scopes:
+                - user:email
+                - user:name
+                - user:login
+                - repo
+      includes:
+        - orchestrator-catalog.yaml
+        - orchestrator-auth.yaml
+      backend:
+        auth:
+          externalAccess:
+            - options:
+                secret: ${BACKEND_SECRET}
+                subject: legacy-default-config
+              type: legacy
+        baseUrl: __RHDH_BASE_URL__
+        cors:
+          origin: __RHDH_BASE_URL__
+        database:
+          connection:
+            password: ${POSTGRESQL_ADMIN_PASSWORD}
+            user: postgres
+      argocd:
+        appLocatorMethods:
+          - instances:
+              - name: main
+                url: ${ARGOCD_URL}
+                username: ${ARGOCD_USERNAME}
+                password: ${ARGOCD_PASSWORD}
+            type: config
+    extraEnvVarsSecrets:
+      - orchestrator-auth-secret
+    extraAppConfig:
+      - configMapRef: orchestrator-catalog
+        filename: orchestrator-catalog.yaml
+      - configMapRef: orchestrator-auth
+        filename: orchestrator-auth.yaml
+    extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "janus-idp.backend-secret-name" $ }}'
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: '{{- include "janus-idp.postgresql.secretName" . }}'
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0" 
+
+orchestrator:
+  enabled: true
+  serverlessLogicOperator:
+    enabled: true
+  serverlessOperator:
+    enabled: true
+  sonataflowPlatform:
+    monitoring:
+      enabled: true
+    eventing:
+      broker:
+        name: ""
+        namespace: ""
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"
+    # -- Secret name for the user-created secret to connect an external DB
+    externalDBsecretRef: ""
+
+    # -- Name for the user-configured external Database
+    externalDBName: ""
+
+    # -- Host for the user-configured external Database
+    externalDBHost: ""
+
+    # -- Port for the user-configured external Database
+    externalDBPort: ""
+
+    # -- Image for the init container used by the create-db job
+    initContainerImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
+
+    # -- Image for the container used by the create-db job
+    createDBJobImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
+
+  # -- Orchestrator plugins and their configuration
+  plugins:
+    # RHDHBUGS-1464: Note that the plugins here fetch the packages from their direct HTTP download URLs from the (official) Red Hat NPM Registry.
+    # Previously, we were using the "@redhat/plugin@version" form along with injecting a .npmrc Secret to resolve the "@redhat" scope,
+    # but this caused conflicting issues with user-provided .npmrc secrets.
+    - disabled: false
+      package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-backend-dynamic/-/backstage-plugin-orchestrator-backend-dynamic-1.6.0.tgz"
+      integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service.{{ .Release.Namespace }}
+    - disabled: false
+      package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator/-/backstage-plugin-orchestrator-1.6.0.tgz"
+      integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator:
+              appIcons:
+                - importName: OrchestratorIcon
+                  name: orchestratorIcon
+              dynamicRoutes:
+                - importName: OrchestratorPage
+                  menuItem:
+                    icon: orchestratorIcon
+                    text: Orchestrator
+                  path: /orchestrator
+    - disabled: false
+      package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic/-/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0.tgz"
+      integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service.{{ .Release.Namespace }}
+    - disabled: false
+      package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-form-widgets/-/backstage-plugin-orchestrator-form-widgets-1.6.0.tgz"
+      integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}

--- a/charts/orchestrator-software-templates/templates/NOTES.txt
+++ b/charts/orchestrator-software-templates/templates/NOTES.txt
@@ -1,0 +1,69 @@
+{{/* Empty line */}}
+Helm Release {{ .Release.Name }} installed in namespace {{ .Release.Namespace }}.
+
+Prerequisites check:
+{{- if not (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
+WARN: CRD for tekton.dev/v1/Task is not installed
+{{- else }}
+The required CRD tekton.dev/v1/Task is already installed.
+{{- end }}
+{{- if not (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
+WARN: CRD for tekton.dev/v1/Pipeline is not installed
+{{- else }}
+The required CRD tekton.dev/v1/Pipeline is already installed.
+{{- end }}
+{{- if not (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/AppProject") }}
+WARN: CRD for argoproj.io/v1alpha1/AppProject is not installed
+{{- else }}
+The required CRD argoproj.io/v1alpha1/AppProject is already installed.
+{{- end }}
+====================================================================
+
+{{- if .Values.rhdhConfig.enabled }}
+Software Templates Configuration:
+  - Authentication integrations configured for supported SCM providers
+  - Catalog locations configured for orchestrator workflows
+  - ConfigMaps created with label 'rhdh.redhat.com/ext-config-sync: true'
+
+{{- $secret := lookup "v1" "Secret" .Values.orchestratorTemplates.rhdhChartNamespace .Values.rhdhConfig.secretRef.name }}
+{{- if $secret }}
+Required secret '{{ .Values.rhdhConfig.secretRef.name }}' found in namespace '{{ .Values.orchestratorTemplates.rhdhChartNamespace }}'
+{{- else }}
+Warning: Secret '{{ .Values.rhdhConfig.secretRef.name }}' not found in namespace '{{ .Values.orchestratorTemplates.rhdhChartNamespace }}'
+{{- end }}
+{{- end }}
+
+====================================================================
+Next Steps:
+====================================================================
+
+1. Create your environment-specific values file:
+   
+   # Get your RHDH route URL
+   RHDH_ROUTE="https://$(oc get route -n {{ .Values.orchestratorTemplates.rhdhChartNamespace }} -o jsonpath='{.items[0].spec.host}')"
+   
+   # Copy template and replace placeholders
+   cp charts/orchestrator-software-templates/orchestrator-templates-values.yaml.template orchestrator-templates-values.yaml
+   sed -i "s|__RHDH_BASE_URL__|$RHDH_ROUTE|g" orchestrator-templates-values.yaml
+
+2. Backup current values and upgrade backstage chart:
+   
+   # Backup current configuration
+   helm show values charts/backstage \
+     -n {{ .Values.orchestratorTemplates.rhdhChartNamespace }} > current-backstage-values.yaml
+   
+   # Upgrade with both value files
+   helm upgrade {{ .Values.orchestratorTemplates.rhdhChartReleaseName }} charts/backstage \
+     -n {{ .Values.orchestratorTemplates.rhdhChartNamespace }} \
+     -f current-backstage-values.yaml \
+     -f orchestrator-templates-values.yaml
+
+3. Wait for the backstage deployment to finish rollout
+
+4. Access your RHDH instance and check the 'Create' section for new software templates.
+
+
+For more information, visit:
+https://github.com/redhat-developer/rhdh-chart
+
+{{/* Empty line */}}

--- a/charts/orchestrator-software-templates/templates/_helpers.tpl
+++ b/charts/orchestrator-software-templates/templates/_helpers.tpl
@@ -1,0 +1,150 @@
+{{/* Helper functions */}}
+
+{{- define "unmanaged-resource-exists" -}}
+    {{- $api := index . 0 -}}
+    {{- $kind := index . 1 -}}
+    {{- $namespace := index . 2 -}}
+    {{- $name := index . 3 -}}
+    {{- $releaseName := index . 4 -}}
+    {{- $apiCapabilities := index . 5 -}}
+    {{- $unmanagedSubscriptionExists := "true" -}}
+    {{- if $apiCapabilities.Has (printf "%s/%s" $api $kind) }}
+        {{- $existingOperator := lookup $api $kind $namespace $name -}}
+        {{- if empty $existingOperator -}}
+            {{- "false" -}}
+        {{- else -}}
+            {{- $isManagedResource := include "is-managed-resource" (list $existingOperator $releaseName) -}}
+            {{- if eq $isManagedResource "true" -}}
+                {{- "false" -}}
+            {{- else -}}
+                {{- "true" -}}
+            {{- end -}}
+        {{- end -}}
+    {{- else -}}
+        {{- "false" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "is-managed-resource" -}}
+    {{- $resource := index . 0 -}}
+    {{- $releaseName := index . 1 -}}
+    {{- $resourceReleaseName := dig "metadata" "annotations" (dict "meta.helm.sh/release-name" "NA") $resource -}}
+    {{- if eq (get $resourceReleaseName "meta.helm.sh/release-name") $releaseName -}}
+        {{- "true" -}}
+    {{- else -}}
+        {{- "false" -}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- define "cluster.domain" -}}
+    {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1/Ingress" -}}
+        {{- $cluster := (lookup "config.openshift.io/v1" "Ingress" "" "cluster") -}}
+        {{- if and (hasKey $cluster "spec") (hasKey $cluster.spec "domain") -}}
+            {{- printf "%s" $cluster.spec.domain -}}
+        {{- else -}}
+            {{ fail "Unable to obtain cluster domain, OCP Ingress Resource is missing the `spec.domain` field." }}
+        {{- end }}
+    {{- else -}}
+        {{ fail "Unable to obtain cluster domain, config.openshift.io/v1/Ingress is missing" }}
+    {{- end -}}
+{{- end -}}
+
+
+{{- define "install-tekton-task" -}}
+  {{- if and (and (and .Values.tekton.enabled .Values.argocd.enabled) (ne .Values.rhdhConfig.secretRef.k8s.clusterToken "")) (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
+        {{- "true" -}}
+    {{- else }}
+        {{- "false" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "install-tekton-pipeline" -}}
+  {{- if and (and (and .Values.tekton.enabled .Values.argocd.enabled) (ne .Values.rhdhConfig.secretRef.k8s.clusterToken "")) (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
+        {{- "true" -}}
+    {{- else }}
+        {{- "false" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "install-argocd-project" -}}
+    {{- if and (.Values.argocd.enabled) (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/AppProject") }}
+        {{- "true" -}}
+    {{- else }}
+        {{- "false" -}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- define "get-namespace-with-label" -}}
+    {{- $paramValue:= index . 0 -}}
+    {{- $matchingLabel:= index . 1 -}}
+    {{- if $paramValue -}}
+        {{- $paramValue -}}
+    {{- else -}}
+        {{- $ns:= "" }}
+        {{- $list:= lookup "v1" "Namespace" "" "" -}}
+        {{- if eq 0 (len (dig "items" (dict "" "") $list ) )}}
+            {{- fail (printf "No namespaces found: %d" (len (dig "items" (dict "" "") $list))  ) }}
+        {{- end -}}
+        {{- range (dig "items" (dict "" "") $list) }}
+            {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
+            {{- if (hasKey $labels $matchingLabel ) }}
+                {{- if not $ns }}
+                    {{- $ns = dig "metadata" "name" "" . -}}
+                {{- else -}}
+                    {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
+                {{- end }}
+            {{- end -}}
+        {{- end -}}
+        {{- if not $ns -}}
+            {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
+        {{- end }}
+        {{- $ns }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "get-workflow-namespace" -}}
+    {{- if (not (hasKey . "workflowNamespace" ) ) -}}
+        {{- $workflowNamespace := include "get-namespace-with-label" (list .Values.orchestrator.namespace "rhdh.redhat.com/workflow-namespace")  }}
+        {{- $_ := set . "workflowNamespace" $workflowNamespace }}
+    {{- end -}}
+    {{- .workflowNamespace -}}
+{{- end -}}
+
+{{- define "get-argocd-namespace" -}}
+    {{- if .Values.argocd.enabled }}
+        {{- if (not (hasKey . "argoCDNamespace" ) ) -}}
+            #{{- $argoCDNamespace := include "get-namespace-with-label" (list .Values.argocd.namespace "rhdh.redhat.com/argocd-namespace")  }}
+            #{{- $_ := set . "argoCDNamespace" $argoCDNamespace }}
+            {{- $_ := set . "argoCDNamespace" .Values.argocd.argocdNamespace }}
+        {{- end -}}
+        {{- .argoCDNamespace -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "get-cluster-version" -}}
+  {{- $v := "" }}
+  {{- $version :=(lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
+  {{- range $version.status.history }}
+    {{- if eq .state "Completed" }}
+      {{- $v = (semver .version) }}
+    {{- end }}
+  {{- end }}
+
+  {{- $validMinors := list "4.13" "4.14" "4.15" "4.16" -}}
+  {{- $versionString := printf "%d.%d" $v.Major $v.Minor -}}
+  {{- if not (semverCompare ">=4.13 <=4.16" $versionString) -}}
+    {{- fail (printf "Unsupported OCP version: %s. Supported versions: %s." $versionString $validMinors) -}}
+  {{- end -}}
+  {{- $versionString -}}
+{{- end -}}
+
+{{- define "get-tekton-version" -}}
+        {{- $pipelinesSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" "openshift-operators" "openshift-pipelines-operator-rh" -}}
+        {{- $pipelineInstalledVersion := $pipelinesSubs.status.installedCSV}}
+        {{- $pipelineVersion := substr 33 ( len $pipelineInstalledVersion) $pipelineInstalledVersion}}
+        {{- $pipelineVersion = semver $pipelineVersion }}
+        {{- $pipelineVersionString := printf "%d.%d" $pipelineVersion.Major $pipelineVersion.Minor -}}
+        {{- $pipelineVersionString -}}
+{{- end -}}

--- a/charts/orchestrator-software-templates/templates/_helpers.tpl
+++ b/charts/orchestrator-software-templates/templates/_helpers.tpl
@@ -82,23 +82,26 @@
     {{- if $paramValue -}}
         {{- $paramValue -}}
     {{- else -}}
+        {{/* Only validate namespace existence during actual deployment, not during template testing */}}
         {{- $ns:= "" }}
         {{- $list:= lookup "v1" "Namespace" "" "" -}}
-        {{- if eq 0 (len (dig "items" (dict "" "") $list ) )}}
-            {{- fail (printf "No namespaces found: %d" (len (dig "items" (dict "" "") $list))  ) }}
-        {{- end -}}
-        {{- range (dig "items" (dict "" "") $list) }}
-            {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
-            {{- if (hasKey $labels $matchingLabel ) }}
-                {{- if not $ns }}
-                    {{- $ns = dig "metadata" "name" "" . -}}
-                {{- else -}}
-                    {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
-                {{- end }}
+        {{- if $list -}}
+            {{- if eq 0 (len (dig "items" (dict "" "") $list ) )}}
+                {{- fail (printf "No namespaces found: %d" (len (dig "items" (dict "" "") $list))  ) }}
             {{- end -}}
-        {{- end -}}
-        {{- if not $ns -}}
-            {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
+            {{- range (dig "items" (dict "" "") $list) }}
+                {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
+                {{- if (hasKey $labels $matchingLabel ) }}
+                    {{- if not $ns }}
+                        {{- $ns = dig "metadata" "name" "" . -}}
+                    {{- else -}}
+                        {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
+                    {{- end }}
+                {{- end -}}
+            {{- end -}}
+            {{- if not $ns -}}
+                {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
+            {{- end }}
         {{- end }}
         {{- $ns }}
     {{- end -}}

--- a/charts/orchestrator-software-templates/templates/argocd/argocd-project.yaml
+++ b/charts/orchestrator-software-templates/templates/argocd/argocd-project.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: orchestrator-gitops
-  namespace: {{ include "get-argocd-namespace" . }}
+  namespace: {{ .Values.argocd.argocdNamespace }}
 spec:
   destinations:
   - name: '*'

--- a/charts/orchestrator-software-templates/templates/argocd/arocd-project.yaml
+++ b/charts/orchestrator-software-templates/templates/argocd/arocd-project.yaml
@@ -1,0 +1,14 @@
+{{- if eq "true" (include "install-argocd-project" .) }}
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: orchestrator-gitops
+  namespace: {{ include "get-argocd-namespace" . }}
+spec:
+  destinations:
+  - name: '*'
+    namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+{{- end }}

--- a/charts/orchestrator-software-templates/templates/rbac.yaml
+++ b/charts/orchestrator-software-templates/templates/rbac.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage
+  namespace: {{ .Values.orchestratorTemplates.rhdhChartNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Values.argocd.argocdNamespace }}
+  name: backstage-k8s-read
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-4"
+rules:
+  - apiGroups:
+      [
+        "",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "tekton.dev",
+        "route.openshift.io",
+        "autoscaling",
+      ]
+    resources:
+      [
+        "pods",
+        "services",
+        "configmaps",
+        "limitranges",
+        "resourcequotas",
+        "deployments",
+        "replicasets",
+        "statefulsets",
+        "jobs",
+        "cronjobs",
+        "ingresses",
+        "horizontalpodautoscalers",
+        "pipelines",
+        "pipelineruns",
+        "taskruns",
+        "routes",
+        "daemonsets",
+      ]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Values.argocd.argocdNamespace }}
+  name: backstage-k8s-read-binding
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-3"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backstage-k8s-read
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: {{ .Values.orchestratorTemplates.rhdhChartNamespace }}

--- a/charts/orchestrator-software-templates/templates/software-templates/orchestrator-auth.yaml
+++ b/charts/orchestrator-software-templates/templates/software-templates/orchestrator-auth.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.rhdhConfig.enabled }}
+{{- if not .Values.rhdhConfig.secretRef.name }}
+  {{- fail "Backstage's secret name defined in 'rhdhConfig.secretRef.name' is required" }}
+{{- end }}
+{{- $secret := lookup "v1" "Secret" .Values.orchestratorTemplates.rhdhChartNamespace .Values.rhdhConfig.secretRef.name }}
+{{- if not $secret }}
+  {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhConfig.secretRef.name .Values.orchestratorTemplates.rhdhChartNamespace ) }}
+{{- end }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    rhdh.redhat.com/ext-config-sync: "true"
+data:
+  orchestrator-auth.yaml: |
+    {{- if and .Values.rhdhConfig.secretRef.github.token (dig "data" .Values.rhdhConfig.secretRef.github.token "" $secret) }}
+    integrations:
+      github:
+        - host: github.com
+          token: {{ printf "${%s}" .Values.rhdhConfig.secretRef.github.token }}
+    {{- end }}
+    {{- if and (and .Values.rhdhConfig.secretRef.gitlab.token (dig "data" .Values.rhdhConfig.secretRef.gitlab.token "" $secret) )
+               (and .Values.rhdhConfig.secretRef.gitlab.host (dig "data" .Values.rhdhConfig.secretRef.gitlab.host "" $secret  ) ) }}
+      gitlab:
+        - host: {{ printf "${%s}" .Values.rhdhConfig.secretRef.gitlab.host }}
+          token: {{ printf "${%s}" .Values.rhdhConfig.secretRef.gitlab.token }}
+          apiBaseUrl: https://{{ printf "${%s}" .Values.rhdhConfig.secretRef.gitlab.host }}/api/v4
+    {{- end }}
+    {{- if and .Values.rhdhConfig.secretRef.github.token (dig "data" .Values.rhdhConfig.secretRef.github.token "" $secret) }}
+    auth:
+      environment: development
+      providers:
+    {{- end }}
+    {{- if and (and .Values.rhdhConfig.secretRef.github.clientId (dig "data" .Values.rhdhConfig.secretRef.github.clientId "" $secret) )
+               (and .Values.rhdhConfig.secretRef.github.clientSecret  (dig "data" .Values.rhdhConfig.secretRef.github.clientSecret "" $secret  ) ) }}
+        github:
+          development:
+            clientId: {{ printf "${%s}" .Values.rhdhConfig.secretRef.github.clientId }}
+            clientSecret: {{ printf "${%s}" .Values.rhdhConfig.secretRef.github.clientSecret }}
+    {{- end }}
+    {{- if .Values.rhdhConfig.enableGuestProvider }}
+        guest:
+          dangerouslyAllowOutsideDevelopment: true
+          userEntityRef: user:default/guest
+    {{- end }}
+{{- end }}

--- a/charts/orchestrator-software-templates/templates/software-templates/orchestrator-auth.yaml
+++ b/charts/orchestrator-software-templates/templates/software-templates/orchestrator-auth.yaml
@@ -2,9 +2,14 @@
 {{- if not .Values.rhdhConfig.secretRef.name }}
   {{- fail "Backstage's secret name defined in 'rhdhConfig.secretRef.name' is required" }}
 {{- end }}
-{{- $secret := lookup "v1" "Secret" .Values.orchestratorTemplates.rhdhChartNamespace .Values.rhdhConfig.secretRef.name }}
-{{- if not $secret }}
-  {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhConfig.secretRef.name .Values.orchestratorTemplates.rhdhChartNamespace ) }}
+{{/* Only validate secret existence during actual deployment, not during template testing */}}
+{{- $secret := dict }}
+{{- $nsExists := lookup "v1" "Namespace" "" .Values.orchestratorTemplates.rhdhChartNamespace }}
+{{- if $nsExists }}
+  {{- $secret = lookup "v1" "Secret" .Values.orchestratorTemplates.rhdhChartNamespace .Values.rhdhConfig.secretRef.name }}
+  {{- if not $secret }}
+    {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhConfig.secretRef.name .Values.orchestratorTemplates.rhdhChartNamespace ) }}
+  {{- end }}
 {{- end }}
 
 apiVersion: v1

--- a/charts/orchestrator-software-templates/templates/software-templates/orchestrator-catalog.yaml
+++ b/charts/orchestrator-software-templates/templates/software-templates/orchestrator-catalog.yaml
@@ -1,0 +1,40 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: orchestrator-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    rhdh.redhat.com/ext-config-sync: "true"
+data:
+  "orchestrator-catalog.yaml": |
+    catalog:
+      rules:
+        - allow:
+            [
+              Component,
+              System,
+              Group,
+              Resource,
+              Location,
+              Template,
+              API,
+              User,
+              Domain,
+            ]
+      locations:
+      {{- if .Values.rhdhConfig.enableGuestProvider }}
+        - type: url
+          target: https://github.com/rhdhorchestrator/orchestrator-helm-chart/blob/main/resources/users.yaml
+      {{- end }}
+        - type: url
+          target: https://github.com/rhdhorchestrator/workflow-software-templates/blob/main/entities/workflow-resources.yaml
+        - type: url
+          target: https://github.com/rhdhorchestrator/workflow-software-templates/blob/main/scaffolder-templates/github-workflows/basic-workflow/template.yaml
+        - type: url
+          target: https://github.com/rhdhorchestrator/workflow-software-templates/blob/main/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+        - type: url
+          target: https://github.com/rhdhorchestrator/workflow-software-templates/blob/main/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+        - type: url
+          target: https://github.com/rhdhorchestrator/workflow-software-templates/blob/main/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+        - type: url
+          target: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator-common/src/generated/docs/api-doc/orchestrator-api.yaml

--- a/charts/orchestrator-software-templates/templates/tekton/tekton-pipeline.yaml
+++ b/charts/orchestrator-software-templates/templates/tekton/tekton-pipeline.yaml
@@ -1,0 +1,175 @@
+{{- if eq "true" (include "install-tekton-pipeline" .) }}
+  {{- $gitopsNamespace := include "get-argocd-namespace" . }}
+  {{- $version := include "get-tekton-version" . }}
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: workflow-deployment
+  namespace: {{ .Values.argocd.argocdNamespace }}
+spec:
+  description: |
+    This pipeline clones a git repo, builds a Docker image with Kaniko and pushes it to a registry
+  params:
+    - name: gitUrl
+      description: The SSH URL of the repository to clone
+      type: string
+    - name: gitOpsUrl
+      description: The SSH URL of the config repository for pushing the changes
+      type: string
+    - name: workflowId
+      description: The workflow ID from the repository
+      type: string
+    - name: convertToFlat
+      description: Whether conversion to flat layout is needed or it's already flattened
+      type: string
+      default: "true"
+    - name: quayOrgName
+      description: The Quay Organization Name of the published workflow
+      type: string
+    - name: quayRepoName
+      description: The Quay Repository Name of the published workflow
+      type: string
+  workspaces:
+    - name: workflow-source
+    - name: workflow-gitops
+    - name: ssh-creds
+    - name: docker-credentials
+  tasks:
+    - name: fetch-workflow
+      taskRef:
+        name: git-cli
+      workspaces:
+        - name: source
+          workspace: workflow-source
+        - name: ssh-directory
+          workspace: ssh-creds
+      params:
+        - name: GIT_USER_NAME
+          value: The Orchestrator Tekton Pipeline
+        - name: GIT_USER_EMAIL
+          value: rhdhorchestrator@redhat.com
+        - name: USER_HOME
+          value: /home/git
+        - name: GIT_SCRIPT
+          value: |
+            eval "$(ssh-agent -s)"
+            ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
+            git clone $(params.gitUrl) workflow
+            cd workflow
+    - name: fetch-workflow-gitops
+      taskRef:
+        name: git-cli
+      workspaces:
+        - name: source
+          workspace: workflow-gitops
+        - name: ssh-directory
+          workspace: ssh-creds
+      params:
+        - name: GIT_USER_NAME
+          value: The Orchestrator Tekton Pipeline
+        - name: GIT_USER_EMAIL
+          value: rhdhorchestrator@redhat.com
+        - name: USER_HOME
+          value: /home/git
+        - name: GIT_SCRIPT
+          value: |
+            eval "$(ssh-agent -s)"
+            ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
+            git clone $(params.gitOpsUrl) workflow-gitops
+    - name: flatten-workflow
+      runAfter: ["fetch-workflow"]
+      taskRef:
+        name: flattener
+      workspaces:
+        - name: workflow-source
+          workspace: workflow-source
+      params:
+        - name: workflowId
+          value: $(params.workflowId)
+        - name: convertToFlat
+          value: $(params.convertToFlat)
+    - name: build-manifests
+      runAfter: ["flatten-workflow"]
+      taskRef:
+        name: build-manifests
+      workspaces:
+        - name: workflow-source
+          workspace: workflow-source
+      params:
+        - name: workflowId
+          value: $(params.workflowId)
+    - name: build-gitops
+      runAfter: ["build-manifests", "fetch-workflow-gitops"]
+      taskRef:
+        name: build-gitops
+      workspaces:
+        - name: workflow-source
+          workspace: workflow-source
+        - name: workflow-gitops
+          workspace: workflow-gitops
+      params:
+        - name: workflowId
+          value: $(params.workflowId)
+        - name: imageTag
+          value: $(tasks.fetch-workflow.results.commit)
+    - name: build-and-push-image
+      runAfter: ["flatten-workflow"]
+      taskRef:
+{{- if (semverCompare ">=1.17" $version) }}
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: buildah
+        - name: namespace
+          value: openshift-pipelines
+{{- else }}
+        name: buildah
+        kind: ClusterTask
+{{- end }}
+      workspaces:
+        - name: source
+          workspace: workflow-source
+        - name: dockerconfig
+          workspace: docker-credentials
+      params:
+        - name: IMAGE
+          value: quay.io/$(params.quayOrgName)/$(params.quayRepoName):$(tasks.fetch-workflow.results.commit)
+        - name: DOCKERFILE
+          value: flat/workflow-builder.Dockerfile
+        - name: CONTEXT
+          value: flat/$(params.workflowId)
+        - name: BUILD_EXTRA_ARGS
+          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES=. '
+    - name: push-workflow-gitops
+      runAfter: ["build-gitops", "build-and-push-image"]
+      taskRef:
+        name: git-cli
+      workspaces:
+        - name: source
+          workspace: workflow-gitops
+        - name: ssh-directory
+          workspace: ssh-creds
+      params:
+        - name: GIT_USER_NAME
+          value: The Orchestrator Tekton Pipeline
+        - name: GIT_USER_EMAIL
+          value: rhdhorchestrator@redhat.com
+        - name: USER_HOME
+          value: /home/git
+        - name: GIT_SCRIPT
+          value: |
+            WORKFLOW_COMMIT=$(tasks.fetch-workflow.results.commit)
+
+            eval "$(ssh-agent -s)"
+            ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
+
+            cd workflow-gitops
+            git add .
+            git diff
+            # TODO: create PR
+            git commit -m "Deployment for workflow commit $WORKFLOW_COMMIT from $(params.gitUrl)"
+            # TODO: parametrize branch
+            git push origin main
+{{- end }}

--- a/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
+++ b/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
@@ -1,0 +1,244 @@
+
+# From https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-cli/0.4/git-cli.yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: git-cli
+  namespace: {{ .Values.argocd.argocdNamespace }}
+  labels:
+    app.kubernetes.io/version: "0.4"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.21.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git cli"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This task can be used to perform git operations.
+
+    Git command that needs to be run can be passed as a script to
+    the task. This task needs authentication to git in order to push
+    after the git operation.
+
+  workspaces:
+    - name: source
+      description: A workspace that contains the fetched git repository.
+
+    - name: input
+      optional: true
+      description: |
+        An optional workspace that contains the files that need to be added to git. You can
+        access the workspace from your script using `$(workspaces.input.path)`, for instance:
+
+          cp $(workspaces.input.path)/file_that_i_want .
+          git add file_that_i_want
+          # etc
+
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+  params:
+    - name: BASE_IMAGE
+      description: |
+        The base image for the task.
+      type: string
+      # TODO: Deprecate use of root image.
+      default: cgr.dev/chainguard/git:root-2.39@sha256:7759f87050dd8bacabe61354d75ccd7f864d6b6f8ec42697db7159eccd491139
+
+    - name: GIT_USER_NAME
+      type: string
+      description: |
+        Git user name for performing git operation.
+      default: ""
+
+    - name: GIT_USER_EMAIL
+      type: string
+      description: |
+        Git user email for performing git operation.
+      default: ""
+
+    - name: GIT_SCRIPT
+      description: The git script to run.
+      type: string
+      default: |
+        git help
+
+    - name: USER_HOME
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      type: string
+      default: "/root"
+
+    - name: VERBOSE
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+
+  results:
+    - name: commit
+      description: The precise commit SHA after the git operation.
+
+  steps:
+    - name: git
+      image: $(params.BASE_IMAGE)
+      workingDir: $(workspaces.source.path)
+      env:
+      - name: HOME
+        value: $(params.USER_HOME)
+      - name: PARAM_VERBOSE
+        value: $(params.VERBOSE)
+      - name: PARAM_USER_HOME
+        value: $(params.USER_HOME)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
+      - name: WORKSPACE_SSH_DIRECTORY_BOUND
+        value: $(workspaces.ssh-directory.bound)
+      - name: WORKSPACE_SSH_DIRECTORY_PATH
+        value: $(workspaces.ssh-directory.path)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+        value: $(workspaces.basic-auth.bound)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+        value: $(workspaces.basic-auth.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        # Setting up the config for the git.
+        git config --global user.email "$(params.GIT_USER_EMAIL)"
+        git config --global user.name "$(params.GIT_USER_NAME)"
+
+        eval '$(params.GIT_SCRIPT)'
+
+        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
+        EXIT_CODE="$?"
+        if [ "$EXIT_CODE" != 0 ]
+        then
+          exit $EXIT_CODE
+        fi
+        # Make sure we don't add a trailing newline to the result!
+        printf "%s" "$RESULT_SHA" > "$(results.commit.path)"
+      # Patch to apply on OpenShift
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: flattener
+  namespace: {{ .Values.argocd.argocdNamespace }}
+spec:
+  workspaces:
+    - name: workflow-source
+  params:
+    - name: workflowId
+      description: The workflow ID from the repository
+      type: string
+    - name: convertToFlat
+      description: Whether conversion to flat layout is needed or it's already flattened
+      type: string
+      default: "true"
+  steps:
+    - name: flatten
+      image: registry.access.redhat.com/ubi9-minimal
+      workingDir: $(workspaces.workflow-source.path)
+      script: |
+        ROOT=/workspace/workflow
+        TARGET=flat
+        mkdir -p flat
+
+        if [ -d "workflow/$(params.workflowId)" ]; then
+          cp -r workflow/$(params.workflowId)/src/main/resources flat/$(params.workflowId)
+          cp workflow/$(params.workflowId)/LICENSE flat/$(params.workflowId)
+        else
+          cp -r workflow/src/main/resources flat/$(params.workflowId)
+          cp workflow/LICENSE flat/$(params.workflowId)
+        fi
+
+        if [ "$(params.convertToFlat)" == "false" ]; then
+          rm -rf workflow/src/main/resources
+          mv workflow/src flat/$(params.workflowId)/
+        fi
+
+        ls flat/$(params.workflowId)
+
+        curl -L https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/v1.4.x/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-manifests
+  namespace: {{ .Values.argocd.argocdNamespace }}
+spec:
+  workspaces:
+    - name: workflow-source
+  params:
+    - name: workflowId
+      description: The workflow ID from the repository
+      type: string
+  steps:
+    - name: build-manifests
+      image: registry.access.redhat.com/ubi9-minimal
+      workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
+      script: |
+        microdnf install -y tar gzip
+        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.35.0/kn-workflow-linux-amd64.tar.gz"
+        curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 kn-workflow
+        ./kn-workflow gen-manifest --namespace ""
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-gitops
+  namespace: {{ .Values.argocd.argocdNamespace }}
+spec:
+  workspaces:
+    - name: workflow-source
+    - name: workflow-gitops
+  params:
+    - name: workflowId
+      description: The workflow ID from the repository
+      type: string
+    - name: imageTag
+      type: string
+  steps:
+    - name: build-gitops
+      image: registry.access.redhat.com/ubi9-minimal
+      workingDir: $(workspaces.workflow-gitops.path)/workflow-gitops
+      script: |
+        cp $(workspaces.workflow-source.path)/flat/$(params.workflowId)/manifests/* kustomize/base
+        microdnf install -y findutils && microdnf clean all
+        cd kustomize
+        ./updater.sh $(params.workflowId) $(params.imageTag)

--- a/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
+++ b/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
@@ -1,4 +1,3 @@
-
 # From https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-cli/0.4/git-cli.yaml
 apiVersion: tekton.dev/v1
 kind: Task
@@ -98,22 +97,22 @@ spec:
       image: $(params.BASE_IMAGE)
       workingDir: $(workspaces.source.path)
       env:
-      - name: HOME
-        value: $(params.USER_HOME)
-      - name: PARAM_VERBOSE
-        value: $(params.VERBOSE)
-      - name: PARAM_USER_HOME
-        value: $(params.USER_HOME)
-      - name: WORKSPACE_OUTPUT_PATH
-        value: $(workspaces.output.path)
-      - name: WORKSPACE_SSH_DIRECTORY_BOUND
-        value: $(workspaces.ssh-directory.bound)
-      - name: WORKSPACE_SSH_DIRECTORY_PATH
-        value: $(workspaces.ssh-directory.path)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-        value: $(workspaces.basic-auth.bound)
-      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-        value: $(workspaces.basic-auth.path)
+        - name: HOME
+          value: $(params.USER_HOME)
+        - name: PARAM_VERBOSE
+          value: $(params.VERBOSE)
+        - name: PARAM_USER_HOME
+          value: $(params.USER_HOME)
+        - name: WORKSPACE_OUTPUT_PATH
+          value: $(workspaces.output.path)
+        - name: WORKSPACE_SSH_DIRECTORY_BOUND
+          value: $(workspaces.ssh-directory.bound)
+        - name: WORKSPACE_SSH_DIRECTORY_PATH
+          value: $(workspaces.ssh-directory.path)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
       script: |
         #!/usr/bin/env sh
         set -eu

--- a/charts/orchestrator-software-templates/values.yaml
+++ b/charts/orchestrator-software-templates/values.yaml
@@ -1,0 +1,50 @@
+orchestratorTemplates:
+  enabled: true
+  rhdhChartReleaseName: rhdh
+  rhdhChartNamespace: rhdh
+
+tekton:
+  enabled: true
+
+argocd:
+  enabled: true
+  # -- References the ArgoCD instance created by infra chart
+  argocdNamespace: orchestrator-gitops
+
+rhdhConfig:
+  secretRef:
+    # -- Name of the secret containing the configuration
+    name: orchestrator-auth-secret
+    backstage:
+      # -- Key in the secret for backend authentication
+      backendSecret: BACKEND_SECRET
+    k8s:
+      # -- Key in the secret for Kubernetes cluster token
+      clusterToken: K8S_CLUSTER_TOKEN
+      # -- Key in the secret for Kubernetes cluster URL
+      clusterUrl: K8S_CLUSTER_URL
+    github:
+      # -- Key in the secret for GitHub token
+      token: GITHUB_TOKEN
+      # -- Key in the secret for GitHub client ID
+      clientId: GITHUB_CLIENT_ID
+      # -- Key in the secret for GitHub client secret
+      clientSecret: GITHUB_CLIENT_SECRET
+    gitlab:
+      # -- Key in the secret for GitLab host
+      host: GITLAB_HOST
+      # -- Key in the secret for GitLab token
+      token: GITLAB_TOKEN
+    argocd:
+      # -- Key in the secret for ArgoCD URL
+      url: ARGOCD_URL
+      # -- Key in the secret for ArgoCD username
+      username: ARGOCD_USERNAME
+      # -- Key in the secret for ArgoCD password
+      password: ARGOCD_PASSWORD
+  # -- Enable RHDH operator
+  enabled: true
+  # -- Enable guest authentication provider
+  enableGuestProvider: false
+  # -- Branch to use for catalog templates
+  catalogBranch: main

--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -3,3 +3,8 @@ chart-dirs:
 validate-maintainers: false
 remote: origin
 helm-extra-args: --timeout 500s
+# Excluding software template charts - which are for demo purposes
+excluded-charts:
+  - orchestrator-software-templates
+  - orchestrator-software-templates-infra
+

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,7 @@ chart-dirs:
 validate-maintainers: false
 remote: origin
 helm-extra-args: --timeout 500s
+# Excluding software template charts - which are for demo purposes
+excluded-charts:
+  - orchestrator-software-templates
+  - orchestrator-software-templates-infra

--- a/hack/merge_secrets.sh
+++ b/hack/merge_secrets.sh
@@ -25,8 +25,8 @@ base64_encode() {
 temp_secret1_file=$(mktemp)
 temp_secret2_file=$(mktemp)
 
-cat "$secret1_file" | yq e '.data[".dockerconfigjson"]' | base64 -d > "$temp_secret1_file"
-cat "$secret2_file" | yq e '.data[".dockerconfigjson"]' | base64 -d > "$temp_secret2_file"
+yq e '.data[".dockerconfigjson"]' "$secret1_file" | base64 -d > "$temp_secret1_file"
+yq e '.data[".dockerconfigjson"]' "$secret2_file" | base64 -d > "$temp_secret2_file"
 
 # Merge the decoded files
 merged_secret_file=$(mktemp)
@@ -44,7 +44,7 @@ metadata:
   namespace: orchestrator-gitops
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: $(cat $encoded_merged_secret)" > docker-credentials-secret.yaml
+  .dockerconfigjson: $(cat "$encoded_merged_secret")" > docker-credentials-secret.yaml
 
 # Clean up temporary files
 rm "$temp_secret1_file" "$temp_secret2_file" "$merged_secret_file" "$encoded_merged_secret"

--- a/hack/merge_secrets.sh
+++ b/hack/merge_secrets.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# The script merges two given K8s secrets in yaml format into a single secret named 'docker-credentials' in 'orchestrator-gitops' namespace.
+# This script is required to simplify the instruction of
+# https://github.com/rhdhorchestrator/orchestrator-helm-operator/tree/main/docs/gitops#installing-docker-credentials
+
+# Check if the correct number of arguments is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <secret1_file> <secret2_file>"
+    exit 1
+fi
+
+# Read the input arguments
+secret1_file=$1
+secret2_file=$2
+
+# Function to base64 encode a file
+base64_encode() {
+    local input_file=$1
+    local output_file=$2
+    base64 -w 0 "$input_file" > "$output_file"
+}
+
+# Decode the secrets into temporary files
+temp_secret1_file=$(mktemp)
+temp_secret2_file=$(mktemp)
+
+cat "$secret1_file" | yq e '.data[".dockerconfigjson"]' | base64 -d > "$temp_secret1_file"
+cat "$secret2_file" | yq e '.data[".dockerconfigjson"]' | base64 -d > "$temp_secret2_file"
+
+# Merge the decoded files
+merged_secret_file=$(mktemp)
+cat "$temp_secret1_file" "$temp_secret2_file" | jq -s '.[0] * .[1]' > "$merged_secret_file"
+
+# Encode the merged secret back to base64
+encoded_merged_secret=$(mktemp)
+base64_encode "$merged_secret_file" "$encoded_merged_secret"
+
+# Create the new secret YAML
+echo "apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-credentials
+  namespace: orchestrator-gitops
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: $(cat $encoded_merged_secret)" > docker-credentials-secret.yaml
+
+# Clean up temporary files
+rm "$temp_secret1_file" "$temp_secret2_file" "$merged_secret_file" "$encoded_merged_secret"
+
+echo "Merged secret created: docker-credentials-secret.yaml"

--- a/hack/orchestrator-templates-setup.sh
+++ b/hack/orchestrator-templates-setup.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+
+
+function captureSetupNewRHDHDeployment {
+  if $use_default; then
+    NEW_ENVIRONMENT=true
+  else
+    echo "Setup for a new RHDH deployment?:"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) NEW_ENVIRONMENT=true; break;;
+            No ) NEW_ENVIRONMENT=false; break;;
+        esac
+    done
+  fi
+}
+
+function captureRHDHNamespace {
+  default="rhdh"
+  if [ "$use_default" == true ]; then
+    rhdh_workspace="$default"
+  else
+    read -p "Enter RHDH Operator namespace (default: $default): " value
+    if [ -z "$value" ]; then
+        rhdh_workspace="$default"
+    else
+        rhdh_workspace="$value"
+    fi
+  fi
+  RHDH_NAMESPACE=$rhdh_workspace
+}
+
+function captureWorkflowNamespace {
+  default="rhdh"
+  if [ "$use_default" == true ]; then
+    workflow_namespace="$default"
+  else
+    read -p "Enter workflow namespace (default: $default): " value
+    if [ -z "$value" ]; then
+        workflow_namespace="$default"
+    else
+        workflow_namespace="$value"
+    fi
+  fi
+  WORKFLOW_NAMESPACE=$workflow_namespace
+}
+
+function captureK8sURL {
+  url="$(oc whoami --show-server)"
+  K8S_CLUSTER_URL=$url
+}
+
+function generateBackendSecret {
+  BACKEND_SECRET=$(mktemp -u XXXXXXXXXXXXXXXXXXXXXXX)
+}
+
+function generateK8sToken {
+  sa_namespace="rhdh"
+  sa_name="rhdh"
+  if [ "$use_default" == false ]; then
+    read -p "Which namespace should be used or created to check the SA holding the persistent token? (default: $sa_namespace): "
+    if [ -n "$sa_namespace" ]; then
+      sa_namespace="$sa_namespace"
+    fi
+
+    read -p "What is the name of the SA? (default: $sa_name): " selected_name
+    if [ -n "$selected_name" ]; then
+      sa_name="$selected_name"
+    fi
+  fi
+  if oc get namespace "$sa_namespace" &> /dev/null; then
+    echo "Namespace '$sa_namespace' already exists."
+  else
+    echo "Namespace '$sa_namespace' does not exist. Creating..."
+    oc create namespace "$sa_namespace"
+  fi
+
+  if oc get sa -n "$sa_namespace" $sa_name &> /dev/null; then
+    echo "ServiceAccount '$sa_name' already exists in '$sa_namespace'."
+  else
+    echo "ServiceAccount '$sa_name' does not exist in '$sa_namespace'. Creating..."
+    oc create sa "$sa_name" -n "$sa_namespace"
+  fi
+
+  oc adm policy add-cluster-role-to-user cluster-admin -z $sa_name -n $sa_namespace
+  echo "Added cluster-admin role to '$sa_name' in '$sa_namespace'."
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: ${sa_name}
+  namespace: ${sa_namespace}
+  annotations:
+    kubernetes.io/service-account.name: orchestrator
+EOF
+
+  K8S_CLUSTER_TOKEN=$(oc -n $sa_namespace get secret/${sa_name} -o jsonpath='{.data.token}' | base64 -d )
+}
+
+function captureGitToken {
+   if [ -z "$GITHUB_TOKEN" ]; then
+    read -s -p "Enter GitHub access token: " value
+    echo ""
+    GITHUB_TOKEN=$value
+  else
+    echo "GitHub access token already set."
+  fi
+}
+
+function captureGitlabToken {
+   if [ -z "$GITLAB_TOKEN" ]; then
+    read -s -p "Enter Gitlab user access token: " value
+    echo ""
+    GITLAB_TOKEN=$value
+  else
+    echo "Gitlab access token already set."
+  fi
+}
+
+function captureGitlabHost {
+   if [ -z "$GITLAB_HOST" ]; then
+    read -s -p "Enter Gitlab host name: " value
+    echo ""
+    GITLAB_HOST=$value
+  else
+    echo "Gitlab host already set."
+  fi
+}
+
+function captureGitClientId {
+   if [ -z "$GITHUB_CLIENT_ID" ]; then
+    read -s -p "Enter GitHub client ID (empty for disabling it): " value
+    echo ""
+    GITHUB_CLIENT_ID=$value
+  else
+    echo "GitHub client ID already set."
+  fi
+}
+
+function captureGitClientSecret {
+   if [ -z "$GITHUB_CLIENT_SECRET" ]; then
+    read -s -p "Enter GitHub client secret (empty for disabling it): " value
+    echo ""
+    GITHUB_CLIENT_SECRET=$value
+  else
+    echo "GitHub client secret already set."
+  fi
+}
+
+function captureArgoCDNamespace {
+  default="orchestrator-gitops"
+  if [ "$use_default" == true ]; then
+    argocd_namespace="$default"
+  else
+    read -p "Enter ArgoCD installation namespace (default: $default): " value
+
+    if [ -z "$value" ]; then
+        argocd_namespace="$default"
+    else
+        argocd_namespace="$value"
+    fi
+  fi
+  ARGOCD_NAMESPACE=$argocd_namespace
+}
+
+function captureArgoCDURL {
+  argocd_instances=$(oc get argocd -n "$ARGOCD_NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+  if [ -z "$argocd_instances" ]; then
+      echo "No ArgoCD instances found in namespace $ARGOCD_NAMESPACE. Continuing without ArgoCD support"
+  else
+    if [ "$use_default" == true ]; then
+          selected_instance=$(echo "$argocd_instances" | awk 'NR==1')
+          echo "Select an ArgoCD instance: $selected_instance"
+    else
+      echo "Select an ArgoCD instance:"
+      select instance in $argocd_instances; do
+          if [ -n "$instance" ]; then
+              selected_instance="$instance"
+              break
+          else
+              echo "Invalid selection. Please choose a valid option."
+          fi
+      done
+    fi
+    argocd_route=$(oc get route -n $ARGOCD_NAMESPACE -l app.kubernetes.io/managed-by=$selected_instance -ojsonpath='{.items[0].status.ingress[0].host}')
+    echo "Found Route at $argocd_route"
+    ARGOCD_URL=https://$argocd_route
+  fi
+
+}
+
+function captureArgoCDCreds {
+  if [ -n "$selected_instance" ]; then
+    admin_password=$(oc get secret -n $ARGOCD_NAMESPACE ${selected_instance}-cluster -ojsonpath='{.data.admin\.password}' | base64 -d)
+    ARGOCD_USERNAME=admin
+    ARGOCD_PASSWORD=$admin_password
+  fi
+}
+
+function captureNotificationsEmailHostname {
+   if [ -z "$NOTIFICATIONS_EMAIL_HOSTNAME" ]; then
+    read -p "Enter the SMTP server hostname for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_HOSTNAME=$value
+  else
+    echo "SMTP server hostname for notification emails already set."
+  fi
+}
+
+function captureNotificationsEmailUsername {
+   if [ -z "$NOTIFICATIONS_EMAIL_USERNAME" ]; then
+    read -p "Enter the SMTP server username for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_USERNAME=$value
+  else
+    echo "SMTP server username for notification emails already set."
+  fi
+}
+
+function captureNotificationsEmailPassword {
+   if [ -z "$NOTIFICATIONS_EMAIL_PASSWORD" ]; then
+    read -s -p "Enter the SMTP server password for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_PASSWORD=$value
+  else
+    echo "SMTP server password for notification emails already set."
+  fi
+}
+
+function setupNotificationsEmailConfig {
+  if $use_default; then
+    if [ -z "${SETUP_NOTIFICATIONS_EMAIL+x}" ]; then
+      SETUP_NOTIFICATIONS_EMAIL=false
+    fi
+  else
+    echo "Setup a notifications email plugin?:"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) SETUP_NOTIFICATIONS_EMAIL=true; break;;
+            No ) SETUP_NOTIFICATIONS_EMAIL=false; break;;
+        esac
+    done
+  fi
+}
+
+function checkPrerequisite {
+  if ! command -v oc &> /dev/null; then
+    echo "oc is required for this script to run. Exiting."
+    exit 1
+  fi
+}
+
+function createBackstageSecret {
+  if 2>/dev/null 1>&2 oc get secret orchestrator-auth-secret -n $RHDH_NAMESPACE; then
+    oc delete secret orchestrator-auth-secret -n $RHDH_NAMESPACE
+  fi
+  declare -A secretKeys
+  if [ -n "$K8S_CLUSTER_URL" ]; then
+    secretKeys[K8S_CLUSTER_URL]=$K8S_CLUSTER_URL
+  fi
+  if [ -n "$K8S_CLUSTER_TOKEN" ]; then
+    secretKeys[K8S_CLUSTER_TOKEN]=$K8S_CLUSTER_TOKEN
+  fi
+  if [ -n "$ARGOCD_USERNAME" ]; then
+    secretKeys[ARGOCD_USERNAME]=$ARGOCD_USERNAME
+  fi
+  if [ -n "$ARGOCD_URL" ]; then
+    secretKeys[ARGOCD_URL]=$ARGOCD_URL
+  fi
+  if [ -n "$ARGOCD_PASSWORD" ]; then
+    secretKeys[ARGOCD_PASSWORD]=$ARGOCD_PASSWORD
+  fi
+  if [ -n "$GITHUB_TOKEN" ]; then
+    secretKeys[GITHUB_TOKEN]=$GITHUB_TOKEN
+  fi
+  if [ -n "$GITLAB_TOKEN" ]; then
+    secretKeys[GITLAB_TOKEN]=$GITLAB_TOKEN
+  fi
+  if [ -n "$GITLAB_HOST" ]; then
+    secretKeys[GITLAB_HOST]=$GITLAB_HOST
+  fi
+  if [ -n "$GITHUB_CLIENT_ID" ]; then
+    secretKeys[GITHUB_CLIENT_ID]=$GITHUB_CLIENT_ID
+  fi
+  if [ -n "$GITHUB_CLIENT_SECRET" ]; then
+    secretKeys[GITHUB_CLIENT_SECRET]=$GITHUB_CLIENT_SECRET
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_HOSTNAME" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_HOSTNAME]=$NOTIFICATIONS_EMAIL_HOSTNAME
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_USERNAME" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_USERNAME]=$NOTIFICATIONS_EMAIL_USERNAME
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_PASSWORD" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_PASSWORD]=$NOTIFICATIONS_EMAIL_PASSWORD
+  fi
+  cmd="oc create secret generic orchestrator-auth-secret -n $RHDH_NAMESPACE --from-literal=BACKEND_SECRET=$BACKEND_SECRET"
+  for key in "${!secretKeys[@]}"; do
+    cmd="${cmd} --from-literal=${key}=${secretKeys[$key]}"
+  done
+  eval $cmd
+}
+
+function labelNamespaces {
+  for a in $(oc get namespace -l rhdh.redhat.com/workflow-namespace -oname); do
+    oc label $a rhdh.redhat.com/workflow-namespace- ;
+  done
+  for a in $(oc get namespace -l rhdh.redhat.com/argocd-namespace -oname); do
+    oc label $a rhdh.redhat.com/argocd-namespace- ;
+  done
+  if [ -n "$WORKFLOW_NAMESPACE" ]; then
+    oc label namespace $WORKFLOW_NAMESPACE rhdh.redhat.com/workflow-namespace=
+  fi
+  if [[ -n "$ARGOCD_NAMESPACE" && -n "$ARGOCD_PASSWORD" && -n "$ARGOCD_URL" && -n "$ARGOCD_USERNAME" ]]; then
+    oc label namespace $ARGOCD_NAMESPACE rhdh.redhat.com/argocd-namespace=
+  fi
+}
+
+# Function to display usage instructions
+display_usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  -h, --help        Display usage instructions"
+    echo "  --use-default     Specify to use all default values"
+    exit 1
+}
+
+# Initialize variable
+use_default=false
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            display_usage
+            ;;
+        --use-default)
+            use_default=true
+            ;;
+        *)
+            echo "Error: Invalid option $1"
+            display_usage
+            ;;
+    esac
+    shift
+done
+
+function main {
+
+  # Check if using default values or not
+  if $use_default; then
+      echo "Using default values."
+  else
+      echo "Not using default values."
+  fi
+
+  checkPrerequisite
+  captureSetupNewRHDHDeployment
+  captureWorkflowNamespace
+  captureArgoCDNamespace
+  captureArgoCDURL
+  captureArgoCDCreds
+  labelNamespaces
+  if $NEW_ENVIRONMENT; then
+    generateBackendSecret
+    captureK8sURL
+    generateK8sToken
+    captureGitToken
+    captureGitClientId
+    captureGitClientSecret
+    captureGitlabHost
+    captureGitlabToken
+    setupNotificationsEmailConfig
+    if $SETUP_NOTIFICATIONS_EMAIL; then
+      captureNotificationsEmailHostname
+      captureNotificationsEmailUsername
+      captureNotificationsEmailPassword
+    fi
+    captureRHDHNamespace
+    createBackstageSecret
+  fi
+  echo "Setup completed successfully!"
+}
+
+main
+


### PR DESCRIPTION
This PR will introduce the new helm chart "Orchestrator-Software-templates" which will be responsible for adding the orchestrator software templates to the RHDH catalog of an existing rhdh deployment. This chart will also create authentication config maps, update dynamic plugins, and give instructions for configuring and running software templates on the catalog, using ArgoCD and Tekton for building and deploying the software projects that were created by the templates, and run the software project with Orchestrator plugin, via RHDH. 

This proccess is a multistage proccess that includes many manual steps. This Helm Chart eases many of the steps, and refferes to the outsourced steps in the README and in the NOTES.txt.   

This Chart is related to this Epic: https://issues.redhat.com/browse/RHIDP-7592 

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Introduce a new Helm chart to automate the integration of workflow software templates into an existing RHDH deployment and provide a setup script for post-install resource configuration.

New Features:
- Add hack/orchestrator-templates-setup.sh to guide and automate creation of namespaces, secrets, service accounts, tokens, and ArgoCD credentials for RHDH Orchestrator
- Introduce orchestrator-software-templates Helm chart with templates for Tekton tasks, pipeline, ArgoCD AppProject, and Backstage catalog and authentication ConfigMaps
- Provide values.yaml defaults for orchestratorTemplates, Tekton, ArgoCD, and RHDH configuration to drive chart installation