### PR TITLE
chore: bumping osl default version to 1.36 in orchestrator-infra

### DIFF
--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.2.0
+version: 0.2.1

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
@@ -90,7 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serverlessLogicOperator.subscription.spec.name | name of the operator package | string | `"logic-operator-rhel8"` |
 | serverlessLogicOperator.subscription.spec.source | name of the catalog source | string | `"redhat-operators"` |
 | serverlessLogicOperator.subscription.spec.sourceNamespace |  | string | `"openshift-marketplace"` |
-| serverlessLogicOperator.subscription.spec.startingCSV | The initial version of the operator, must match CRDs installed by the chart | string | `"logic-operator-rhel8.v1.35.0"` |
+| serverlessLogicOperator.subscription.spec.startingCSV | The initial version of the operator, must match CRDs installed by the chart | string | `"logic-operator-rhel8.v1.36.0"` |
 | serverlessOperator.enabled | whether the operator should be deployed by the chart | bool | `true` |
 | serverlessOperator.subscription.namespace | namespace where the operator should be deployed | string | `"openshift-serverless"` |
 | serverlessOperator.subscription.spec.channel | channel of an operator package to subscribe to | string | `"stable"` |
@@ -111,7 +111,7 @@ After installing the openshift-serverless subscription, more Knative CRDs will b
 The versions of the CRDs present in the chart and the ones in the subscrtiprion must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash
-docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.35.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml
+docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml
 
-docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.35.0 /manifests/operator_v1beta1_knativeserving_crd.yaml > knative-serving-crd.yaml
+docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeserving_crd.yaml > knative-serving-crd.yaml
 ```

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -108,7 +108,7 @@ The orchestrator-infra chart requires several CRDs for Knative Eventing and Knat
 The KnativeEventing and KnativeServing CRDs are required for this chart to run. These CRDs need to be present under the crds/ directory before running `helm install`.
 After installing the openshift-serverless subscription, more Knative CRDs will be installed on the cluster.
 
-The versions of the CRDs present in the chart and the ones in the subscrtiprion must match. In order to verify the correct CRD, use this following command to extract the CRD:
+The versions of the CRDs present in the chart and the ones in the subscription must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash
 docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -83,7 +83,7 @@ The orchestrator-infra chart requires several CRDs for Knative Eventing and Knat
 The KnativeEventing and KnativeServing CRDs are required for this chart to run. These CRDs need to be present under the crds/ directory before running `helm install`. 
 After installing the openshift-serverless subscription, more Knative CRDs will be installed on the cluster. 
 
-The versions of the CRDs present in the chart and the ones in the subscrtiprion must match. In order to verify the correct CRD, use this following command to extract the CRD:
+The versions of the CRDs present in the chart and the ones in the subscription must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash 
 docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -86,7 +86,7 @@ After installing the openshift-serverless subscription, more Knative CRDs will b
 The versions of the CRDs present in the chart and the ones in the subscrtiprion must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash 
-docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.35.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml
+docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeeventing_crd.yaml > knative-eventing-crd.yaml
 
-docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.35.0 /manifests/operator_v1beta1_knativeserving_crd.yaml > knative-serving-crd.yaml
+docker run --rm --entrypoint cat registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.36.0 /manifests/operator_v1beta1_knativeserving_crd.yaml > knative-serving-crd.yaml
 ```

--- a/charts/orchestrator-infra/values.yaml
+++ b/charts/orchestrator-infra/values.yaml
@@ -15,7 +15,7 @@ serverlessLogicOperator:
       source: redhat-operators
       sourceNamespace: openshift-marketplace
       # -- The initial version of the operator, must match CRDs installed by the chart
-      startingCSV: logic-operator-rhel8.v1.35.0
+      startingCSV: logic-operator-rhel8.v1.36.0
 
 serverlessOperator:
   # -- whether the operator should be deployed by the chart


### PR DESCRIPTION
## Description of the change

<!-- Describe the change being requested. -->
We need to bump the default OSL version in orchestrator-infra chart, as Orchestrater now requires most recent version. 
``` 
      startingCSV: logic-operator-rhel8.v1.36.0
```
Related to this bug:
https://issues.redhat.com/browse/FLPATH-2543

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [x] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Bump the default OpenShift Serverless Logic Operator to v1.36.0 and update the orchestrator-infra chart version and docs accordingly.

Enhancements:
- Bump default serverlessLogicOperator.subscription.spec.startingCSV to logic-operator-rhel8.v1.36.0

Documentation:
- Update README version badge and CRD extraction commands to reference operator bundle v1.36.0

Chores:
- Update orchestrator-infra chart version from 0.2.0 to 0.2.1