### PR TITLE
cherry-picking np fix, chart bump

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.4.3
+version: 4.4.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 4.4.3](https://img.shields.io/badge/Version-4.4.3-informational?style=flat-square)
+![Version: 4.4.4](https://img.shields.io/badge/Version-4.4.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.

--- a/charts/backstage/templates/network-policies.yaml
+++ b/charts/backstage/templates/network-policies.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-allow-knative-to-sonataflow-and-workflows
+  name: {{ .Release.Name }}-allow-infra-ns-to-workflow-ns
   # Sonataflow and Workflows are using the RHDH target namespace.
   namespace: {{ .Release.Namespace | quote }}
 spec:
@@ -17,6 +17,11 @@ spec:
           matchLabels:
             # Allow auxiliary knative function for workflow (such as m2k-save-transformation)
             kubernetes.io/metadata.name: knative-serving
+      - namespaceSelector:
+          matchLabels:
+            # Allow communication between the serverless logic operator and the workflow namespace.
+            kubernetes.io/metadata.name: openshift-serverless-logic
+      
 ---
 # NetworkPolicy to unblock incoming traffic to the namespace
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
This PR will backport the fix intoduced on main through [this PR](https://github.com/redhat-developer/rhdh-chart/pull/207). 
The PR will fix a bug with a missing network policy in Orchestrator related configuration in the backstage chart. 

This change is related to a bug captured [here](https://issues.redhat.com/browse/FLPATH-2613)

And this PR will relate to [this Jira issue](https://issues.redhat.com/browse/FLPATH-2615).

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Backport the network policy fix into the Backstage Helm chart to restore proper orchestration namespace access and bump the chart version accordingly

Bug Fixes:
- Rename the network policy to reflect infra-to-workflow namespace permissions
- Add a namespaceSelector for openshift-serverless-logic to the network policy to allow required communication

Documentation:
- Update the README version badge to 4.4.4

Chores:
- Bump the Backstage chart version to 4.4.4