### PR TITLE
fix(ci): Make sure to checkout the PR branch before pushing the diff generated from the pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(fromJSON('["coreydaley","gazarenkov","kadel","nickboldt","rm3l","kim-tsao","Fortune-Ndlovu","subhashkhileri","zdrapela","openshift-cherrypick-robot", "Fortune-Ndlovu", "subhashkhileri", "zdrapela"]'), github.event.pull_request.user.login)) && 'internal' || 'external' }}
+      contains(fromJSON('["gazarenkov","kadel","nickboldt","rm3l","kim-tsao","Fortune-Ndlovu","subhashkhileri","zdrapela","openshift-cherrypick-robot"]'), github.event.pull_request.user.login)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved
@@ -66,18 +66,22 @@ jobs:
         run: |
           echo "CHANGED=$(if git diff --quiet; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
 
-      - name: Commit any changes
+      - name: Commit and push any manifest changes
         if: ${{ steps.diff-checker.outputs.CHANGED == 'true' }}
         run: |
+          git remote add fork "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          git fetch fork ${{ github.event.pull_request.head.ref }}
+          git checkout -B pr-branch fork/${{ github.event.pull_request.head.ref }}
+
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git fetch --prune
-          git pull --rebase --autostash
+
           git add -A .
           git commit \
             -m "chore(pre-commit): Auto-fix hooks" \
             -m "Co-authored-by: $GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
-          git push
+
+          git push fork pr-branch:${{ github.event.pull_request.head.ref }}
 
       - name: Comment on PR if manifests were updated
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

Applying the same fix done in https://github.com/redhat-developer/rhdh-operator/pull/1599

Context:
- https://github.com/redhat-developer/rhdh-chart/actions/runs/17545997169/job/49827512012?pr=231
- https://github.com/redhat-developer/rhdh-operator/actions/runs/17475391158/job/49670949036?pr=1584

This only affects workflows that have steps that auto-commit/push certain changes to the PR branch.

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

https://github.com/redhat-developer/rhdh-chart/actions/runs/17545997169/job/49827512012?pr=231

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Update the pre-commit GitHub Actions workflow to checkout the PR head branch before committing and pushing auto-fix changes, and refresh the internal approvers list.

CI:
- Ensure the workflow fetches and checks out the PR branch from the fork remote before committing and pushing pre-commit hook fixes
- Remove 'coreydaley' from the internal approvers list in the pre-commit workflow

## Summary by Sourcery

Fix pre-commit GitHub workflow to correctly check out and push auto-generated fixes back to the pull request branch.

Bug Fixes:
- Ensure the workflow fetches and checks out the PR head before committing and pushing pre-commit hook changes.

Enhancements:
- Streamline the internal approvers list for environment selection.
- Remove unnecessary git fetch/pull steps and update push command to target the PR branch.