### PR TITLE
fix(orchestrator-infra): Rename the chart in the README [RHDHBUGS-2021]

### DIFF
--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.1.1
+version: 0.1.2

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.25.0-0`
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-infra redhat-developer/orchestrator-infra
+helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra
 ```
 
 > **Tip**: List all releases using `helm list`

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -20,7 +20,7 @@
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-infra redhat-developer/orchestrator-infra
+helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra
 ```
 
 > **Tip**: List all releases using `helm list`


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

Manual cherry-pick of https://github.com/redhat-developer/rhdh-chart/pull/236

The chart was renamed in [1][2], but the README was still pointing to the
previous chart, which caused users to install an outdated version of the
chart when following this doc.
    
[1] https://issues.redhat.com/browse/RHIDP-6169
[2] https://github.com/redhat-developer/rhdh-chart/pull/131

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHDHBUGS-2021

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Rename the orchestrator-infra chart reference in README, bump chart version to 0.1.2, and align documentation with the renamed chart to prevent users installing the outdated version

Bug Fixes:
- Fix wrong helm install command pointing to the old chart name in orchestrator-infra README

Enhancements:
- Bump orchestrator-infra chart version from 0.1.1 to 0.1.2

Documentation:
- Update README badge and install instruction to use redhat-developer-hub-orchestrator-infra instead of orchestrator-infra

Chores:
- Cherry-pick chart rename changes from upstream PR