### PR TITLE
fix(RHDHBUGS-2015): fix sonataflow DB ref name for replication architecture of PostgreSQL

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 4.4.4
+version: 4.4.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 4.4.4](https://img.shields.io/badge/Version-4.4.4-informational?style=flat-square)
+![Version: 4.4.5](https://img.shields.io/badge/Version-4.4.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -41,7 +41,7 @@ spec:
             userKey: username
             passwordKey: password
           serviceRef:
-            name: {{ .Release.Name }}-postgresql
+            name: {{ .Release.Name }}-postgresql{{- if eq .Values.upstream.postgresql.architecture "replication" }}-primary{{- end }}
             namespace: {{ .Release.Namespace }}
             databaseName: sonataflow
 {{- else }}
@@ -66,7 +66,7 @@ spec:
             userKey: username
             passwordKey: password
           serviceRef:
-            name: {{ .Release.Name }}-postgresql
+            name: {{ .Release.Name }}-postgresql{{- if eq .Values.upstream.postgresql.architecture "replication" }}-primary{{- end }}
             namespace: {{ .Release.Namespace }}
             databaseName: sonataflow
 {{- else }}
@@ -113,7 +113,7 @@ spec:
             - -c
             - |
 {{- if .Values.upstream.postgresql.enabled }}
-              dbHost="{{ .Release.Name }}-postgresql"
+              dbHost="{{ .Release.Name }}-postgresql{{- if eq .Values.upstream.postgresql.architecture "replication" }}-primary{{- end }}"
               dbPort="5432"
 {{- else }}
               dbHost=${POSTGRES_HOST}
@@ -186,7 +186,7 @@ spec:
         command: [ "sh", "-c" ]
 {{- if .Values.upstream.postgresql.enabled }}
         args:
-          - "psql -h {{ .Release.Name }}-postgresql -p 5432 -U postgres -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"
+          - "psql -h {{ .Release.Name }}-postgresql{{- if eq .Values.upstream.postgresql.architecture "replication" }}-primary{{- end }} -p 5432 -U postgres -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"
 {{- else }}
         args:
           - "psql -h ${POSTGRES_HOST} -p ${POSTGRES_PORT} -U ${POSTGRES_USER} -d {{ .Values.orchestrator.sonataflowPlatform.externalDBName }} -c 'CREATE DATABASE sonataflow;' || echo WARNING: Could not create database"


### PR DESCRIPTION
## Description of the change

Manual cherry-pick of https://github.com/redhat-developer/rhdh-chart/pull/235

## Which issue(s) does this PR fix or relate to

Fixes https://issues.redhat.com/browse/RHDHBUGS-2015

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
