### PR TITLE
fixing issue with namespace range

### DIFF
--- a/charts/orchestrator-software-templates-infra/Chart.yaml
+++ b/charts/orchestrator-software-templates-infra/Chart.yaml
@@ -10,7 +10,7 @@ kubeVersion: ">= 1.25.0-0"
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-software-templates-infrastructure
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: Red Hat Developer Hub Team
     url: https://github.com/redhat-developer/rhdh-chart

--- a/charts/orchestrator-software-templates-infra/README.md
+++ b/charts/orchestrator-software-templates-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Software Templates Infra Chart for OpenShift (Community Version)
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to install Openshift GitOps and Openshift Pipelines, which are required operators for installing the Orchestrator Software Templates to be available on RHDH.

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-application-controller-clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
-    app.kubernetes.io/part-of: {{ $.Values.openshiftGitops.namespaces | first }}
+    app.kubernetes.io/part-of: {{ $ns }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -16,10 +16,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ $.Values.openshiftGitops.namespaces | first }}-argocd-application-controller
+  name: {{ $ns }}-argocd-application-controller
 subjects:
 - kind: ServiceAccount
-  name: {{ $.Values.openshiftGitops.name }}-argocd-application-controller
+  name: {{ $ns }}-argocd-application-controller
   namespace: {{ $ns }}
 {{- end }}
 {{- end }}

--- a/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-cr.yaml
+++ b/charts/orchestrator-software-templates-infra/templates/openshift-gitops/argocd-cr.yaml
@@ -5,9 +5,9 @@
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: {{ $.Values.openshiftGitops.name }}
+  name: {{ $ns }}
   labels:
-    app: {{ $.Values.openshiftGitops.name }}
+    app: {{ $ns }}
   namespace: {{ $ns }}
   annotations:
     helm.sh/hook: post-install,post-upgrade


### PR DESCRIPTION
This PR will fix a small issue in the orchestrator-software-templates-infra chart 
in some templates, the namespace range was not working and needed to be fixed. 

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Fix namespace range handling in the openshift-gitops templates by using the current namespace variable for resource names, labels, and bindings, and bump the chart version to 0.2.3.

Bug Fixes:
- Use the dynamic namespace variable ($ns) instead of the first element for ArgoCD ClusterRoleBinding labels, role names, and service account subjects
- Use the dynamic namespace variable ($ns) for ArgoCD custom resource name and app label

Build:
- Bump orchestrator-software-templates-infra chart version to 0.2.3

Documentation:
- Update README badge to reflect chart version 0.2.3