### PR TITLE
Bumping OSL version in tekton task for workflow builder

### DIFF
--- a/charts/orchestrator-software-templates/Chart.yaml
+++ b/charts/orchestrator-software-templates/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">= 1.25.0-0"
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Red Hat Developer Hub Team
     url: https://github.com/redhat-developer/rhdh-chart

--- a/charts/orchestrator-software-templates/README.md
+++ b/charts/orchestrator-software-templates/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Software Templates Chart for Red Hat Developer Hub
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH) and other necessary GitOps configurations.

--- a/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
+++ b/charts/orchestrator-software-templates/templates/tekton/tekton-tasks.yaml
@@ -213,7 +213,7 @@ spec:
       workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
       script: |
         microdnf install -y tar gzip
-        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.35.0/kn-workflow-linux-amd64.tar.gz"
+        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.36.0/kn-workflow-linux-amd64.tar.gz"
         curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 kn-workflow
         ./kn-workflow gen-manifest --namespace ""
 ---


### PR DESCRIPTION
This PR will bump the OSL version used in the kn tool that is used by the tekton task to build the workflow image.
This needs to match to the osl version installed by the orchestrator-infra chart. 


## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [x] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.

## Summary by Sourcery

Align the OSL version used by the kn-workflow CLI in the Tekton task with the orchestrator-infra chart by bumping it to 1.36.0 and update the chart version and documentation

Enhancements:
- Bump kn-workflow CLI version from 1.35.0 to 1.36.0 in the Tekton task for workflow generation
- Upgrade orchestrator-software-templates chart version to 0.1.1 and update the README badge accordingly