### PR TITLE
chore(deps): Bump the versions of the tools installed by `helm/chart-testing-action`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+        with:
+          version: '3.14.0'
+          yamllint_version: '1.37.1'
+          yamale_version: '6.0.0'
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,10 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+        with:
+          version: '3.14.0'
+          yamllint_version: '1.37.1'
+          yamale_version: '6.0.0'
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
## Description of the change

This is a follow-up to [1], to ensure that they work properly with Python 3.14 - see [2]

[1] https://github.com/redhat-developer/rhdh-chart/pull/249

[2] https://github.com/redhat-developer/rhdh-chart/actions/runs/18350355942/job/52268343561?pr=248

## Which issue(s) does this PR fix or relate to

&mdash;

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will do this automatically for you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
