### PR TITLE
feat(must-gather): expose known must-gather env vars as explicit fields in the values file

### DIFF
--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.2.0
+version: 0.3.0

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,7 +1,7 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the RHDH Must-Gather diagnostic tool on Kubernetes
@@ -27,7 +27,7 @@ Kubernetes: `>= 1.27.0-0`
 ```console
 helm upgrade --install my-rhdh-must-gather rhdh-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.2.0
+  --version 0.3.0
 ```
 
 Running the command again will automatically replace the previous pod and start a new gather.
@@ -105,10 +105,17 @@ The command removes all the Kubernetes resources associated with the chart and d
 | dataHolder | Runs alongside the gather container and stays alive so you can exec in and retrieve the output. | object | `{"resources":{"limits":{"cpu":"100m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"50m","ephemeral-storage":"32Mi","memory":"64Mi"}}}` |
 | dataHolder.resources | Resource requests and limits for the data-holder container | object | `{"limits":{"cpu":"100m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"50m","ephemeral-storage":"32Mi","memory":"64Mi"}}` |
 | fullnameOverride |  | string | `""` |
-| gather | Gather script configuration | object | `{"clusterInfo":false,"cmdTimeout":"30","extraArgs":[],"extraEnvVars":[],"logLevel":"info","namespaces":[],"since":"","sinceTime":"","withHeapDumps":false,"withHelm":true,"withIngress":true,"withNamespaceInspect":true,"withOperator":true,"withOrchestrator":true,"withPlatform":true,"withRoute":true,"withSecrets":false}` |
+| gather | Gather script configuration | object | `{"clusterInfo":false,"cmdTimeout":"30","extraArgs":[],"extraEnvVars":[],"heapDump":{"bufferSize":"","enabled":false,"instances":"","method":"","remoteDir":"","timeout":""},"logLevel":"info","namespaces":[],"since":"","sinceTime":"","withHelm":true,"withIngress":true,"withNamespaceInspect":true,"withOperator":true,"withOrchestrator":true,"withPlatform":true,"withRoute":true,"withSecrets":false}` |
 | gather.cmdTimeout | Command timeout for individual kubectl/helm commands (seconds) | string | `"30"` |
 | gather.extraArgs | Additional custom arguments to pass to the gather script | list | `[]` |
 | gather.extraEnvVars | Additional environment variables to pass to the gather init container.<br/> See [Define Environment variables for a container](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container). | list | `[]` |
+| gather.heapDump | Heap dump collection configuration | object | `{"bufferSize":"","enabled":false,"instances":"","method":"","remoteDir":"","timeout":""}` |
+| gather.heapDump.bufferSize | WebSocket buffer size in bytes for inspector method | string | `""` |
+| gather.heapDump.enabled | Enable collection of heap dumps (disabled by default) | bool | `false` |
+| gather.heapDump.instances | Filter for specific heap dump instances (comma-separated pod names or patterns) | string | `""` |
+| gather.heapDump.method | Method for heap dump collection: "inspector" or "sigusr2" | string | `""` |
+| gather.heapDump.remoteDir | Directory in container where heap dumps are written for SIGUSR2 method. Must be writable inside the gather container. | string | `""` |
+| gather.heapDump.timeout | Timeout in seconds for heap dump collection | string | `""` |
 | gather.logLevel | Log level: info, INFO, debug, DEBUG, trace, TRACE | string | `"info"` |
 | gather.namespaces | Example: ["rhdh-prod", "rhdh-staging"] | list | `[]` |
 | gather.since | Relative time for log collection (e.g., "2h", "30m") | string | `""` |

--- a/charts/must-gather/templates/NOTES.txt
+++ b/charts/must-gather/templates/NOTES.txt
@@ -24,7 +24,7 @@ Configuration used:
 {{- if .Values.gather.withSecrets }}
   - Secrets collection: enabled (sanitized)
 {{- end }}
-{{- if .Values.gather.withHeapDumps }}
+{{- if .Values.gather.heapDump.enabled }}
   - Heap dump collection: enabled
 {{- end }}
 

--- a/charts/must-gather/templates/clusterrbac.yaml
+++ b/charts/must-gather/templates/clusterrbac.yaml
@@ -60,7 +60,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"] # NOSONAR - required for data collection
     verbs: ["create"]
-  {{- if .Values.gather.withHeapDumps }}
+  {{- if .Values.gather.heapDump.enabled }}
   - apiGroups: [""]
     resources: ["pods/portforward"]
     verbs: ["create"]

--- a/charts/must-gather/templates/deployment.yaml
+++ b/charts/must-gather/templates/deployment.yaml
@@ -68,6 +68,18 @@ spec:
             - name: MUST_GATHER_SINCE_TIME
               value: {{ .Values.gather.sinceTime | quote }}
             {{- end }}
+            {{- if and .Values.gather.heapDump.enabled .Values.gather.heapDump.timeout }}
+            - name: HEAP_DUMP_TIMEOUT
+              value: {{ .Values.gather.heapDump.timeout | quote }}
+            {{- end }}
+            {{- if and .Values.gather.heapDump.enabled .Values.gather.heapDump.bufferSize }}
+            - name: HEAP_DUMP_BUFFER_SIZE
+              value: {{ .Values.gather.heapDump.bufferSize | quote }}
+            {{- end }}
+            {{- if and .Values.gather.heapDump.enabled .Values.gather.heapDump.remoteDir }}
+            - name: HEAP_DUMP_REMOTE_DIR
+              value: {{ .Values.gather.heapDump.remoteDir | quote }}
+            {{- end }}
             {{- with .Values.gather.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -77,13 +89,21 @@ spec:
           {{- /* Namespace-scoped RBAC: override to release namespace only (gather.namespaces is ignored) */ -}}
           {{- $effectiveNamespaces = list .Release.Namespace }}
           {{- end }}
-          {{- if or $nsScope .Values.gather.withSecrets .Values.gather.withHeapDumps .Values.gather.clusterInfo (not .Values.gather.withOperator) (not .Values.gather.withOrchestrator) (not .Values.gather.withHelm) (not .Values.gather.withPlatform) (not .Values.gather.withRoute) (not .Values.gather.withIngress) (not .Values.gather.withNamespaceInspect) $effectiveNamespaces .Values.gather.extraArgs }}
+          {{- if or $nsScope .Values.gather.withSecrets .Values.gather.heapDump.enabled .Values.gather.clusterInfo (not .Values.gather.withOperator) (not .Values.gather.withOrchestrator) (not .Values.gather.withHelm) (not .Values.gather.withPlatform) (not .Values.gather.withRoute) (not .Values.gather.withIngress) (not .Values.gather.withNamespaceInspect) $effectiveNamespaces .Values.gather.extraArgs }}
           args:
             {{- if .Values.gather.withSecrets }}
             - "--with-secrets"
             {{- end }}
-            {{- if .Values.gather.withHeapDumps }}
+            {{- if .Values.gather.heapDump.enabled }}
             - "--with-heap-dumps"
+            {{- end }}
+            {{- if and .Values.gather.heapDump.enabled .Values.gather.heapDump.method }}
+            - "--heap-dump-method"
+            - {{ .Values.gather.heapDump.method | quote }}
+            {{- end }}
+            {{- if and .Values.gather.heapDump.enabled .Values.gather.heapDump.instances }}
+            - "--heap-dump-instances"
+            - {{ .Values.gather.heapDump.instances | quote }}
             {{- end }}
             {{- if .Values.gather.clusterInfo }}
             - "--cluster-info"

--- a/charts/must-gather/templates/rbac.yaml
+++ b/charts/must-gather/templates/rbac.yaml
@@ -47,7 +47,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"] # NOSONAR - required for data collection
     verbs: ["create"]
-  {{- if .Values.gather.withHeapDumps }}
+  {{- if .Values.gather.heapDump.enabled }}
   - apiGroups: [""]
     resources: ["pods/portforward"]
     verbs: ["create"]

--- a/charts/must-gather/values.schema.json
+++ b/charts/must-gather/values.schema.json
@@ -957,6 +957,48 @@
                     "title": "Additional environment variables to pass to the gather init container.",
                     "type": "array"
                 },
+                "heapDump": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "bufferSize": {
+                            "default": "",
+                            "title": "WebSocket buffer size in bytes for inspector method.",
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "default": false,
+                            "title": "Enable collection of heap dumps (disabled by default).",
+                            "type": "boolean"
+                        },
+                        "instances": {
+                            "default": "",
+                            "title": "Filter for specific heap dump instances (comma-separated pod names or patterns).",
+                            "type": "string"
+                        },
+                        "method": {
+                            "default": "",
+                            "enum": [
+                                "",
+                                "inspector",
+                                "sigusr2"
+                            ],
+                            "title": "Method for heap dump collection: 'inspector' or 'sigusr2'.",
+                            "type": "string"
+                        },
+                        "remoteDir": {
+                            "default": "",
+                            "title": "Directory in container where heap dumps are written for SIGUSR2 method.",
+                            "type": "string"
+                        },
+                        "timeout": {
+                            "default": "",
+                            "title": "Timeout in seconds for heap dump collection.",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Heap dump collection configuration.",
+                    "type": "object"
+                },
                 "logLevel": {
                     "default": "info",
                     "enum": [
@@ -988,11 +1030,6 @@
                     "default": "",
                     "title": "Absolute timestamp for log collection (RFC3339 format).",
                     "type": "string"
-                },
-                "withHeapDumps": {
-                    "default": false,
-                    "title": "Enable collection of heap dumps (disabled by default).",
-                    "type": "boolean"
                 },
                 "withHelm": {
                     "default": true,

--- a/charts/must-gather/values.schema.tmpl.json
+++ b/charts/must-gather/values.schema.tmpl.json
@@ -205,10 +205,43 @@
                     "type": "boolean",
                     "default": false
                 },
-                "withHeapDumps": {
-                    "title": "Enable collection of heap dumps (disabled by default).",
-                    "type": "boolean",
-                    "default": false
+                "heapDump": {
+                    "title": "Heap dump collection configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "Enable collection of heap dumps (disabled by default).",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "method": {
+                            "title": "Method for heap dump collection: 'inspector' or 'sigusr2'.",
+                            "type": "string",
+                            "enum": ["", "inspector", "sigusr2"],
+                            "default": ""
+                        },
+                        "timeout": {
+                            "title": "Timeout in seconds for heap dump collection.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "bufferSize": {
+                            "title": "WebSocket buffer size in bytes for inspector method.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "remoteDir": {
+                            "title": "Directory in container where heap dumps are written for SIGUSR2 method.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "instances": {
+                            "title": "Filter for specific heap dump instances (comma-separated pod names or patterns).",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
                 },
                 "clusterInfo": {
                     "title": "Enable collection of cluster-wide info (disabled by default).",

--- a/charts/must-gather/values.yaml
+++ b/charts/must-gather/values.yaml
@@ -76,8 +76,22 @@ gather:
 
   # -- Optional collection features (disabled by default)
   withSecrets: false
-  withHeapDumps: false
   clusterInfo: false
+
+  # -- Heap dump collection configuration
+  heapDump:
+    # -- Enable collection of heap dumps (disabled by default)
+    enabled: false
+    # -- Method for heap dump collection: "inspector" or "sigusr2"
+    method: ""
+    # -- Timeout in seconds for heap dump collection
+    timeout: ""
+    # -- WebSocket buffer size in bytes for inspector method
+    bufferSize: ""
+    # -- Directory in container where heap dumps are written for SIGUSR2 method. Must be writable inside the gather container.
+    remoteDir: ""
+    # -- Filter for specific heap dump instances (comma-separated pod names or patterns)
+    instances: ""
 
   # -- Collection features (enabled by default; set to false to skip)
   withOperator: true


### PR DESCRIPTION
## Description of the change

This makes it easier to customize.

## Which issue(s) does this PR fix or relate to

&mdash;

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
