### PR TITLE
chore(must-gather): rename the must-gather chart to be consistent with the other chart names

### DIFF
--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -4,14 +4,14 @@ annotations:
   charts.openshift.io/archs: x86_64
   charts.openshift.io/supportURL: https://access.redhat.com/support
 apiVersion: v2
-name: rhdh-must-gather
+name: redhat-developer-hub-must-gather
 description: |
-  A Helm chart for deploying the RHDH Must-Gather diagnostic tool on Kubernetes
+  A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
 
 type: application
 
 # Application version - matches the must-gather tool version
-appVersion: "0.2.0"
+appVersion: "latest"
 
 keywords:
   - rhdh
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.3.0
+version: 0.4.0

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,10 +1,10 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-A Helm chart for deploying the RHDH Must-Gather diagnostic tool on Kubernetes
+A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
 
 **Homepage:** <https://github.com/redhat-developer/rhdh-must-gather>
 
@@ -25,9 +25,9 @@ Kubernetes: `>= 1.27.0-0`
 ## TL;DR
 
 ```console
-helm upgrade --install my-rhdh-must-gather rhdh-must-gather \
+helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.3.0
+  --version 0.4.0
 ```
 
 Running the command again will automatically replace the previous pod and start a new gather.

--- a/charts/must-gather/README.md.gotmpl
+++ b/charts/must-gather/README.md.gotmpl
@@ -18,7 +18,7 @@
 ## TL;DR
 
 ```console
-helm upgrade --install my-rhdh-must-gather rhdh-must-gather \
+helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
   --version {{ template "chart.version" . }}
 ```


### PR DESCRIPTION
## Description of the change

Rename into `redhat-developer-hub-must-gather`, in preparation for publication in the openshift-helm-charts repo.

## Which issue(s) does this PR fix or relate to

Relates to https://redhat.atlassian.net/browse/RHIDP-12627

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
