### PR TITLE
docs(must-gather): update instructions with the `wait` and `timeout` options

### DIFF
--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.4.0
+version: 0.5.0

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,7 +1,7 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
@@ -27,12 +27,18 @@ Kubernetes: `>= 1.27.0-0`
 ```console
 helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.4.0
+  --version 0.5.0 \
+  [--wait --timeout=$duration]
 ```
 
 Running the command again will automatically replace the previous pod and start a new gather.
 
 Then follow the instructions that will be printed to retrieve the gathered data.
+
+When using `--wait`, the `helm` command will return only when the `gather` init container has finished or the specified timeout has elapsed.
+
+Note that the default Helm timeout when using `--wait` is **5m** (5 minutes), which may be too short for the RHDH must-gather to finish collecting diagnostic data.
+Feel free to adjust accordingly.
 
 ## Running on OpenShift
 

--- a/charts/must-gather/README.md.gotmpl
+++ b/charts/must-gather/README.md.gotmpl
@@ -20,12 +20,18 @@
 ```console
 helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version {{ template "chart.version" . }}
+  --version {{ template "chart.version" . }} \
+  [--wait --timeout=$duration]
 ```
 
 Running the command again will automatically replace the previous pod and start a new gather.
 
 Then follow the instructions that will be printed to retrieve the gathered data.
+
+When using `--wait`, the `helm` command will return only when the `gather` init container has finished or the specified timeout has elapsed.
+
+Note that the default Helm timeout when using `--wait` is **5m** (5 minutes), which may be too short for the RHDH must-gather to finish collecting diagnostic data.
+Feel free to adjust accordingly.
 
 ## Running on OpenShift
 


### PR DESCRIPTION
## Description of the change

Update README.

## Which issue(s) does this PR fix or relate to

&mdash;

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
