### PR TITLE
(chore): increase MAX_ENTRY_SIZE for lightspeed

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.8.0
+version: 5.9.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.8.0](https://img.shields.io/badge/Version-5.8.0-informational?style=flat-square)
+![Version: 5.9.0](https://img.shields.io/badge/Version-5.9.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -4995,7 +4995,7 @@
                                         },
                                         {
                                             "name": "MAX_ENTRY_SIZE",
-                                            "value": "30000000"
+                                            "value": "40000000"
                                         },
                                         {
                                             "name": "CATALOG_INDEX_IMAGE",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -383,7 +383,7 @@ upstream:
             value: /opt/app-root/src/.npmrc.dynamic-plugins
             # This following variable is required for orchestrator to startup properly.
           - name: MAX_ENTRY_SIZE
-            value: "30000000"
+            value: "40000000"
           - name: CATALOG_INDEX_IMAGE
             value: '{{ .Values.global.catalogIndex.image.registry }}/{{ .Values.global.catalogIndex.image.repository }}:{{ .Values.global.catalogIndex.image.tag }}'
           - name: CATALOG_ENTITIES_EXTRACT_DIR


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change
- Updates the set `MAX_ENTRY_SIZE` as Lightspeed was failing to install despite https://github.com/redhat-developer/rhdh/commit/d4f996b6cc4a1237fc763a1a0c83efcf59e8cac6 being merged already

<!-- Describe the change being requested. -->

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

N/A

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
