### PR TITLE
chore(lightspeed): use Red Hat plugins with inherit function to handle the references

### DIFF
--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -54,7 +54,7 @@ global:
     enabled: true
     # -- Lightspeed plugins and their configuration. Override package references for disconnected environments.
     plugins:
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.2.1!red-hat-developer-hub-backstage-plugin-lightspeed
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ "{{inherit}}" }}'
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -81,7 +81,7 @@ global:
                     config:
                       id: lightspeed
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.2.1!red-hat-developer-hub-backstage-plugin-lightspeed-backend
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ "{{inherit}}" }}'
         disabled: false
     runtimeVolume:
       # -- Name of the Kubernetes volume used for writable Lightspeed runtime storage.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

Uses Red Hat lightspeed plugins with the `{{inherit}}` plugin installer function to handle matching the current 1.10 references. See [orchestrator](https://github.com/redhat-developer/rhdh-chart/blob/541d1470a46e6a75b19328a0581020d094ad211e/charts/backstage/values.yaml#L565-L573).

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHDHBUGS-3030

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
