### PR TITLE
fix(backstage): correctly render lightspeed image fields regardless if they are `string` or `map` [RHDHBUGS-3091]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.11.0
+version: 5.11.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.11.0](https://img.shields.io/badge/Version-5.11.0-informational?style=flat-square)
+![Version: 5.11.1](https://img.shields.io/badge/Version-5.11.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.11.0
+helm install my-backstage redhat-developer/backstage --version 5.11.1
 ```
 
 ## Introduction

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -50,6 +50,17 @@ Referenced from: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/
 {{- end -}}
 
 {{/*
+Return an image reference from a value that may be a string or a map with registry/repository/tag fields.
+*/}}
+{{- define "backstage.image.render" -}}
+{{- if kindIs "string" .image -}}
+  {{- .image -}}
+{{- else -}}
+  {{- include "common.images.image" (dict "imageRoot" (.image | toYaml | fromYaml) "global" .global) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the configured Lightspeed runtime volume type and validate the required
 source block is present.
 */}}

--- a/charts/backstage/vendor/backstage/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/vendor/backstage/charts/backstage/templates/backstage-deployment.yaml
@@ -131,7 +131,7 @@ spec:
         {{- end }}
         {{- if $lightspeed.enabled }}
         - name: {{ $lightspeed.initContainer.name }}
-          image: {{ include "common.tplvalues.render" (dict "value" $lightspeed.initContainer.image "context" $) }}
+          image: {{ include "backstage.image.render" (dict "image" $lightspeed.initContainer.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ $lightspeed.initContainer.imagePullPolicy | quote }}
           {{- if $lightspeed.initContainer.securityContext }}
           securityContext:
@@ -255,7 +255,7 @@ spec:
           {{- end }}
         {{- if $lightspeed.enabled }}
         - name: {{ $lightspeed.sidecar.name }}
-          image: {{ include "common.tplvalues.render" (dict "value" $lightspeed.sidecar.image "context" $) }}
+          image: {{ include "backstage.image.render" (dict "image" $lightspeed.sidecar.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ $lightspeed.sidecar.imagePullPolicy | quote }}
           {{- if $lightspeed.sidecar.securityContext }}
           securityContext:


### PR DESCRIPTION
## Description of the change

In the rhdh-chart repo, the lightspeed image fields are simple strings in the values file:
https://github.com/redhat-developer/rhdh-chart/blob/3275bcfdc2731b685bb2efaa318730670328bed8/charts/backstage/values.yaml#L150-L153

But in the downstream chart, they are maps (note that the tag/digest is missing as well):
```
    initContainer:
      name: lightspeed-rag-init
      # -- Full image reference for the Lightspeed RAG bootstrap init container. Override for disconnected environments.
      image:
        registry: quay.io
        repository: rhdh/rhdh-rag-content-rhel9@sha256
        # tag is set to digest via prepare.sh script
        # tag: "${RAG_CONTENT_DIGEST}"

        tag: ""
```

## Which issue(s) does this PR fix or relate to

Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3091

## How to test changes / Special notes to the reviewer

Render the backstage chart against the values file mentioned in https://redhat.atlassian.net/browse/RHDHBUGS-3091

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
