### PR TITLE
fix(ci): temporarily pin catalog index image in CI to `1.10-51` to work around wrong lightspeed OCI refs [RHDHBUGS-3095]

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,4 +46,5 @@ jobs:
         with:
           target_branch: ${{ matrix.branch }}
           all_charts: 'true'
-          extra_helm_args: '--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag=${{ steps.image.outputs.tag }} --set upstream.backstage.image.pullPolicy=Always'
+          # TODO(RHDHBUGS-3095): Remove the catalogIndex.image.tag pin once the lightspeed plugins OCI refs are fixed in the latest catalog index image.
+          extra_helm_args: '--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag=${{ steps.image.outputs.tag }} --set upstream.backstage.image.pullPolicy=Always --set global.catalogIndex.image.tag=1.10-51'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,4 +34,5 @@ jobs:
         with:
           target_branch: ${{ github.event.pull_request.base.ref }}
           # The RHDH image tag is already pinned to a specific version for the 'release-1.y' branches.
-          extra_helm_args: ${{ github.event.pull_request.base.ref == 'main' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1}', env.RHDH_IMAGE_REPOSITORY, env.RHDH_IMAGE_TAG) || '' }}
+          # TODO(RHDHBUGS-3095): Remove the catalogIndex.image.tag pin once the lightspeed plugins OCI refs are fixed in the latest catalog index image.
+          extra_helm_args: ${{ github.event.pull_request.base.ref == 'main' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1} --set global.catalogIndex.image.tag=1.10-51', env.RHDH_IMAGE_REPOSITORY, env.RHDH_IMAGE_TAG) || '--set global.catalogIndex.image.tag=1.10-51' }}


### PR DESCRIPTION
## Description of the change

The latest 1.10 catalog index image contains incorrect OCI references for the lightspeed plugins (pointing to ghcr instead of registry.access.redhat.com).
To unblock PR and Nightly checks in this repo, this PR pins to 1.10-51 (containing the expected refs) in CI workflows until this issue is resolved.

## Which issue(s) does this PR fix or relate to

Relates to https://redhat.atlassian.net/browse/RHDHBUGS-3095

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
