### PR TITLE
fix(must-gather): grant `controllerrevisions` access for rollout history [RHIDP-13416]

### DIFF
--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.5.0
+version: 0.5.1

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,7 +1,7 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
@@ -27,7 +27,7 @@ Kubernetes: `>= 1.27.0-0`
 ```console
 helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.5.0 \
+  --version 0.5.1 \
   [--wait --timeout=$duration]
 ```
 

--- a/charts/must-gather/templates/clusterrbac.yaml
+++ b/charts/must-gather/templates/clusterrbac.yaml
@@ -21,7 +21,7 @@ rules:
     resources: ["namespaces", "nodes"]
     verbs: ["get", "list"]
   - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "controllerrevisions"]
     verbs: ["get", "list"]
   {{- if .Values.rbac.rules.platform }}
   - apiGroups: ["config.openshift.io"]

--- a/charts/must-gather/templates/rbac.yaml
+++ b/charts/must-gather/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
     verbs: ["get", "list"]
   {{- end }}
   - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "controllerrevisions"]
     verbs: ["get", "list"]
   {{- if .Values.rbac.rules.ingresses }}
   - apiGroups: ["networking.k8s.io"]


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

Add controllerrevisions to the apps apiGroup resources for the rollout history collector to work correctly in the must-gather image.

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- Relates to [RHIDP-13416](https://redhat.atlassian.net/browse/RHIDP-13416)

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
