### PR TITLE
chore: bump charts minor versions to avoid publishing conflicts with `release-1.10`

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.0
+version: 5.13.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.0](https://img.shields.io/badge/Version-5.12.0-informational?style=flat-square)
+![Version: 5.13.0](https://img.shields.io/badge/Version-5.13.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.0
+helm install my-backstage redhat-developer/backstage --version 5.13.0
 ```
 
 ## Introduction

--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.5.1
+version: 0.6.0

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,7 +1,7 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
@@ -27,7 +27,7 @@ Kubernetes: `>= 1.27.0-0`
 ```console
 helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.5.1 \
+  --version 0.6.0 \
   [--wait --timeout=$duration]
 ```
 

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.5.3
+version: 0.6.0

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.25.0-0`
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.5.3
+helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.6.0
 ```
 
 > **Tip**: List all releases using `helm list`

--- a/charts/orchestrator-software-templates-infra/Chart.yaml
+++ b/charts/orchestrator-software-templates-infra/Chart.yaml
@@ -10,7 +10,7 @@ kubeVersion: ">= 1.25.0-0"
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-software-templates-infrastructure
-version: 0.4.0
+version: 0.5.0
 maintainers:
   - name: Red Hat Developer Hub Team
     url: https://github.com/redhat-developer/rhdh-chart

--- a/charts/orchestrator-software-templates-infra/README.md
+++ b/charts/orchestrator-software-templates-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Software Templates Infra Chart for OpenShift (Community Version)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to install Openshift GitOps and Openshift Pipelines, which are required operators for installing the Orchestrator Software Templates to be available on RHDH.
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.25.0-0`
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-software-templates-infra redhat-developer/orchestrator-software-templates-infra --version 0.4.0
+helm install my-orchestrator-software-templates-infra redhat-developer/orchestrator-software-templates-infra --version 0.5.0
 ```
 
 > **Tip**: List all releases using `helm list`

--- a/charts/orchestrator-software-templates/Chart.yaml
+++ b/charts/orchestrator-software-templates/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">= 1.25.0-0"
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.3.0
+version: 0.4.0
 maintainers:
   - name: Red Hat Developer Hub Team
     url: https://github.com/redhat-developer/rhdh-chart

--- a/charts/orchestrator-software-templates/README.md
+++ b/charts/orchestrator-software-templates/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Software Templates Chart for Red Hat Developer Hub
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This Helm chart deploys the Orchestrator Software Templates for Red Hat Developer Hub (RHDH) and other necessary GitOps configurations.
@@ -78,7 +78,7 @@ After configuring all prerequisites, you can install the chart with the followin
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-templates redhat-developer/orchestrator-software-templates --version 0.3.0
+helm install my-orchestrator-templates redhat-developer/orchestrator-software-templates --version 0.4.0
 ```
 
 Now, follow the instruction on the post-installation Notes. They will include the steps to create a custom values.yaml file to allow you to update the backstage chart


### PR DESCRIPTION
## Description of the change

Bumps charts minor versions to avoid conflicts when they will be packaged from the release-1.10 branch.

## Which issue(s) does this PR fix or relate to

&mdash;

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [x] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
