### PR TITLE
ci: revert "fix(ci): temporarily pin catalog index image in CI to `1.10-51` to work around wrong lightspeed OCI refs [RHDHBUGS-3095]"

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,5 +46,4 @@ jobs:
         with:
           target_branch: ${{ matrix.branch }}
           all_charts: 'true'
-          # TODO(RHDHBUGS-3095): Remove the catalogIndex.image.tag pin once the lightspeed plugins OCI refs are fixed in the latest catalog index image.
-          extra_helm_args: '--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag=${{ steps.image.outputs.tag }} --set upstream.backstage.image.pullPolicy=Always --set global.catalogIndex.image.tag=1.10-51'
+          extra_helm_args: '--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag=${{ steps.image.outputs.tag }} --set upstream.backstage.image.pullPolicy=Always'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,5 +34,4 @@ jobs:
         with:
           target_branch: ${{ github.event.pull_request.base.ref }}
           # The RHDH image tag is already pinned to a specific version for the 'release-1.y' branches.
-          # TODO(RHDHBUGS-3095): Remove the catalogIndex.image.tag pin once the lightspeed plugins OCI refs are fixed in the latest catalog index image.
-          extra_helm_args: ${{ github.event.pull_request.base.ref == 'main' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1} --set global.catalogIndex.image.tag=1.10-51', env.RHDH_IMAGE_REPOSITORY, env.RHDH_IMAGE_TAG) || '--set global.catalogIndex.image.tag=1.10-51' }}
+          extra_helm_args: ${{ github.event.pull_request.base.ref == 'main' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1}', env.RHDH_IMAGE_REPOSITORY, env.RHDH_IMAGE_TAG) || '' }}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

This reverts commit 8e40fbf6308fd4ee2a72b00a8193910f36a0a852.

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- _JIRA_issue_link_

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
