### PR TITLE
fix: Updating OSL version to 1.38.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: helm-dependency-update
         name: helm-dependency-update
         entry: helm dependency update charts/backstage/vendor/backstage/charts/backstage
-        language: unsupported
+        language: system
         pass_filenames: false
         files: charts/backstage/vendor/backstage/charts/backstage/Chart\.(ya?ml|lock)$
       - id: jsonschema-dereference

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: helm-dependency-update
         name: helm-dependency-update
         entry: helm dependency update charts/backstage/vendor/backstage/charts/backstage
-        language: system
+        language: unsupported
         pass_filenames: false
         files: charts/backstage/vendor/backstage/charts/backstage/Chart\.(ya?ml|lock)$
       - id: jsonschema-dereference

--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.6.0
+version: 0.6.1

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.25.0-0`
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.6.0
+helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.6.1
 ```
 
 > **Tip**: List all releases using `helm list`
@@ -90,7 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serverlessLogicOperator.subscription.spec.name | name of the operator package | string | `"logic-operator"` |
 | serverlessLogicOperator.subscription.spec.source | name of the catalog source | string | `"redhat-operators"` |
 | serverlessLogicOperator.subscription.spec.sourceNamespace |  | string | `"openshift-marketplace"` |
-| serverlessLogicOperator.subscription.spec.startingCSV | The initial version of the operator, must match CRDs installed by the chart | string | `"logic-operator.v1.37.2"` |
+| serverlessLogicOperator.subscription.spec.startingCSV | The initial version of the operator, must match CRDs installed by the chart | string | `"logic-operator.v1.38.0"` |
 | serverlessOperator.enabled | whether the operator should be deployed by the chart | bool | `true` |
 | serverlessOperator.subscription.namespace | namespace where the operator should be deployed | string | `"openshift-serverless"` |
 | serverlessOperator.subscription.spec.channel | channel of an operator package to subscribe to | string | `"stable"` |
@@ -111,7 +111,7 @@ After installing the openshift-serverless subscription, more Knative CRDs will b
 The versions of the CRDs present in the chart and the ones in the subscription must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash
-export osl_bundle=registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.37.2
+export osl_bundle=registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.38.0
 podman container run --rm --entrypoint cat "$osl_bundle" /manifests/operator_v1beta1_knativeeventing_crd.yaml > crds/knative-eventing/knative-eventing-crd.yaml
 
 podman container run --rm --entrypoint cat "$osl_bundle" /manifests/operator_v1beta1_knativeserving_crd.yaml > crds/knative-serving/knative-serving-crd.yaml

--- a/charts/orchestrator-infra/README.md.gotmpl
+++ b/charts/orchestrator-infra/README.md.gotmpl
@@ -86,7 +86,7 @@ After installing the openshift-serverless subscription, more Knative CRDs will b
 The versions of the CRDs present in the chart and the ones in the subscription must match. In order to verify the correct CRD, use this following command to extract the CRD:
 
 ```bash
-export osl_bundle=registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.37.2
+export osl_bundle=registry.redhat.io/openshift-serverless-1/serverless-operator-bundle:1.38.0
 podman container run --rm --entrypoint cat "$osl_bundle" /manifests/operator_v1beta1_knativeeventing_crd.yaml > crds/knative-eventing/knative-eventing-crd.yaml
 
 podman container run --rm --entrypoint cat "$osl_bundle" /manifests/operator_v1beta1_knativeserving_crd.yaml > crds/knative-serving/knative-serving-crd.yaml

--- a/charts/orchestrator-infra/templates/tests/infra-test.yaml
+++ b/charts/orchestrator-infra/templates/tests/infra-test.yaml
@@ -107,7 +107,7 @@ spec:
           {{- end }}
             
           {{- if .Values.serverlessLogicOperator.enabled }}
-          kubectl get subscription {{ .Values.serverlessLogicOperator.subscription.name }} -n {{ .Values.serverlessLogicOperator.subscription.namespace }} || exit 1
+          kubectl get subscription {{ .Values.serverlessLogicOperator.subscription.spec.name }} -n {{ .Values.serverlessLogicOperator.subscription.namespace }} || exit 1
           {{- end }}
       
           echo "Test passed!"

--- a/charts/orchestrator-infra/templates/tests/infra-test.yaml
+++ b/charts/orchestrator-infra/templates/tests/infra-test.yaml
@@ -90,10 +90,10 @@ spec:
       resources:
         requests:
           cpu: 10m
-          memory: 20Mi
+          memory: 128Mi
         limits:
           cpu: 10m
-          memory: 20Mi
+          memory: 128Mi
       image: {{ .Values.tests.image }}
       command: ["/bin/sh", "-c"]
       args:

--- a/charts/orchestrator-infra/templates/tests/infra-test.yaml
+++ b/charts/orchestrator-infra/templates/tests/infra-test.yaml
@@ -107,7 +107,7 @@ spec:
           {{- end }}
             
           {{- if .Values.serverlessLogicOperator.enabled }}
-          kubectl get subscription {{ .Values.serverlessLogicOperator.subscription.spec.name }} -n {{ .Values.serverlessLogicOperator.subscription.namespace }} || exit 1
+          kubectl get subscription {{ .Values.serverlessLogicOperator.subscription.name }} -n {{ .Values.serverlessLogicOperator.subscription.namespace }} || exit 1
           {{- end }}
       
           echo "Test passed!"

--- a/charts/orchestrator-infra/templates/tests/infra-test.yaml
+++ b/charts/orchestrator-infra/templates/tests/infra-test.yaml
@@ -90,10 +90,10 @@ spec:
       resources:
         requests:
           cpu: 10m
-          memory: 128Mi
+          memory: 50Mi
         limits:
           cpu: 10m
-          memory: 128Mi
+          memory: 50Mi
       image: {{ .Values.tests.image }}
       command: ["/bin/sh", "-c"]
       args:

--- a/charts/orchestrator-infra/values.schema.json
+++ b/charts/orchestrator-infra/values.schema.json
@@ -46,7 +46,7 @@
                                     "type": "string"
                                 },
                                 "startingCSV": {
-                                    "default": "logic-operator.v1.37.2",
+                                    "default": "logic-operator.v1.38.0",
                                     "title": "The initial version of the operator",
                                     "type": "string"
                                 }

--- a/charts/orchestrator-infra/values.schema.tmpl.json
+++ b/charts/orchestrator-infra/values.schema.tmpl.json
@@ -52,7 +52,7 @@
                   "type": "string"
                 },
                 "startingCSV": {
-                  "default": "logic-operator.v1.37.2",
+                  "default": "logic-operator.v1.38.0",
                   "title": "The initial version of the operator",
                   "type": "string"
                 }

--- a/charts/orchestrator-infra/values.yaml
+++ b/charts/orchestrator-infra/values.yaml
@@ -15,7 +15,7 @@ serverlessLogicOperator:
       source: redhat-operators
       sourceNamespace: openshift-marketplace
       # -- The initial version of the operator, must match CRDs installed by the chart
-      startingCSV: logic-operator.v1.37.2
+      startingCSV: logic-operator.v1.38.0
 
 serverlessOperator:
   # -- whether the operator should be deployed by the chart


### PR DESCRIPTION
## Description of the change

Updating OSL version to 1.38.0

Also updated pre-commit language to system as unsupported was causing the pre-commit to fail when run.

## Which issue(s) does this PR fix or relate to

- [RHIDP-13369](https://redhat.atlassian.net/browse/RHIDP-13369)

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [x] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
