### PR TITLE
fix(orchestrator): make ttlSecondsAfterFinished optional to prevent GitOps reconciliation loops

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 6.0.0
+version: 6.0.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square)
+![Version: 6.0.1](https://img.shields.io/badge/Version-6.0.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 6.0.0
+helm install my-backstage redhat-developer/backstage --version 6.0.1
 ```
 
 ## Introduction
@@ -211,9 +211,9 @@ Kubernetes: `>= 1.27.0-0`
 | orchestrator.serverlessOperator.enabled |  | bool | `true` |
 | orchestrator.sonataflowPlatform.createDBJobImage | Image for the container used by the create-db job | string | `"{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"` |
 | orchestrator.sonataflowPlatform.dataIndexImage | Image for the container used by the sonataflow data index, optional and used for disconnected environments | string | `""` |
-| orchestrator.sonataflowPlatform.dbCreationJobActiveDeadlineSeconds | Maximum time in seconds for the create-db Job to complete before being terminated | int | `120` |
-| orchestrator.sonataflowPlatform.dbCreationJobBackoffLimit | Number of retries for the create-db job if it fails | int | `2` |
-| orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished | Time in seconds after which a finished create-db Job is automatically deleted | int | `300` |
+| orchestrator.sonataflowPlatform.dbCreationJobActiveDeadlineSeconds | Maximum time in seconds for the Sonataflow database creation Job to complete before being terminated | int | `120` |
+| orchestrator.sonataflowPlatform.dbCreationJobBackoffLimit | Number of retries for the Sonataflow database creation job if it fails | int | `2` |
+| orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished | Time in seconds after which the Sonataflow database creation Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD) | int | `nil` |
 | orchestrator.sonataflowPlatform.eventing.broker.name |  | string | `""` |
 | orchestrator.sonataflowPlatform.eventing.broker.namespace |  | string | `""` |
 | orchestrator.sonataflowPlatform.externalDBHost | Host for the user-configured external Database | string | `""` |

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -88,7 +88,9 @@ metadata:
   name: {{ .Release.Name }}-create-sf-db-{{ .Chart.Version | replace "." "-" }}
   namespace: {{ .Release.Namespace }}
 spec:
-  ttlSecondsAfterFinished: {{ .Values.orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished }}
+{{- with .Values.orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+{{- end }}
   activeDeadlineSeconds: {{ .Values.orchestrator.sonataflowPlatform.dbCreationJobActiveDeadlineSeconds }}
   template:
     spec:

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -489,10 +489,12 @@
                             "type": "integer"
                         },
                         "dbCreationJobTTLSecondsAfterFinished": {
-                            "default": 300,
-                            "minimum": 0,
-                            "title": "Time in seconds after which a finished create-db Job is automatically deleted",
-                            "type": "integer"
+                            "minimum": 1,
+                            "title": "Time in seconds after which a finished create-db Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
                         },
                         "eventing": {
                             "additionalProperties": false,

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -478,19 +478,19 @@
                         "dbCreationJobActiveDeadlineSeconds": {
                             "default": 120,
                             "minimum": 1,
-                            "title": "Maximum time in seconds for the create-db Job to complete before being terminated",
+                            "title": "Maximum time in seconds for the Sonataflow database creation Job to complete before being terminated",
                             "type": "integer"
                         },
                         "dbCreationJobBackoffLimit": {
                             "default": 2,
                             "maximum": 10,
                             "minimum": 0,
-                            "title": "Number of retries for the create-db job if it fails",
+                            "title": "Number of retries for the Sonataflow database creation job if it fails",
                             "type": "integer"
                         },
                         "dbCreationJobTTLSecondsAfterFinished": {
                             "minimum": 1,
-                            "title": "Time in seconds after which a finished create-db Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
+                            "title": "Time in seconds after which the Sonataflow database creation Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
                             "type": [
                                 "integer",
                                 "null"

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -483,7 +483,6 @@
                         },
                         "dbCreationJobBackoffLimit": {
                             "default": 2,
-                            "maximum": 10,
                             "minimum": 0,
                             "title": "Number of retries for the Sonataflow database creation job if it fails",
                             "type": "integer"

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -576,10 +576,9 @@
                             "type": "integer"
                         },
                         "dbCreationJobTTLSecondsAfterFinished": {
-                            "default": 300,
-                            "minimum": 0,
-                            "title": "Time in seconds after which a finished create-db Job is automatically deleted",
-                            "type": "integer"
+                            "minimum": 1,
+                            "title": "Time in seconds after which a finished create-db Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
+                            "type": ["integer", "null"]
                         },
                         "dbCreationJobActiveDeadlineSeconds": {
                             "default": 120,

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -572,18 +572,18 @@
                             "default": 2,
                             "maximum": 10,
                             "minimum": 0,
-                            "title": "Number of retries for the create-db job if it fails",
+                            "title": "Number of retries for the Sonataflow database creation job if it fails",
                             "type": "integer"
                         },
                         "dbCreationJobTTLSecondsAfterFinished": {
                             "minimum": 1,
-                            "title": "Time in seconds after which a finished create-db Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
+                            "title": "Time in seconds after which the Sonataflow database creation Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)",
                             "type": ["integer", "null"]
                         },
                         "dbCreationJobActiveDeadlineSeconds": {
                             "default": 120,
                             "minimum": 1,
-                            "title": "Maximum time in seconds for the create-db Job to complete before being terminated",
+                            "title": "Maximum time in seconds for the Sonataflow database creation Job to complete before being terminated",
                             "type": "integer"
                         },
                         "jobServiceImage": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -570,7 +570,6 @@
                         },
                         "dbCreationJobBackoffLimit": {
                             "default": 2,
-                            "maximum": 10,
                             "minimum": 0,
                             "title": "Number of retries for the Sonataflow database creation job if it fails",
                             "type": "integer"

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -533,11 +533,11 @@ orchestrator:
     initContainerImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
     # -- Image for the container used by the create-db job
     createDBJobImage: "{{ .Values.upstream.postgresql.image.registry }}/{{ .Values.upstream.postgresql.image.repository }}:{{ .Values.upstream.postgresql.image.tag }}"
-    # -- Number of retries for the create-db job if it fails
+    # -- Number of retries for the Sonataflow database creation job if it fails
     dbCreationJobBackoffLimit: 2
-    # -- Time in seconds after which a finished create-db Job is automatically deleted
-    dbCreationJobTTLSecondsAfterFinished: 300
-    # -- Maximum time in seconds for the create-db Job to complete before being terminated
+    # -- (int) Time in seconds after which the Sonataflow database creation Job is automatically deleted. Leave empty to disable (recommended for GitOps/ArgoCD)
+    dbCreationJobTTLSecondsAfterFinished:
+    # -- Maximum time in seconds for the Sonataflow database creation Job to complete before being terminated
     dbCreationJobActiveDeadlineSeconds: 120
     # -- Image for the container used by the sonataflow jobs service, optional and used for disconnected environments
     jobServiceImage: ""


### PR DESCRIPTION
## Description of the change

When the chart is managed by a continuous reconciler (e.g., ArgoCD), the `ttlSecondsAfterFinished` field on the `create-sf-db` Job causes an infinite reconciliation loop: the Job finishes, the TTL controller deletes it after 300s, ArgoCD detects drift and recreates it, causing the DB creation script to re-run endlessly.

This PR makes `ttlSecondsAfterFinished` conditional; it is only rendered when explicitly set to a positive value. Users who want auto-cleanup can explicitly set `orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished` to a positive integer.

## Which issue(s) does this PR fix or relate to

- Follow-up to #407

## How to test changes / Special notes to the reviewer

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.