### PR TITLE
[release-1.8] fix(orchestrator-infra): increase infra-test pod memory to fix nightly CI

### DIFF
--- a/charts/orchestrator-infra/Chart.yaml
+++ b/charts/orchestrator-infra/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 type: application
 sources:
   - https://github.com/redhat-developer/rhdh-chart
-version: 0.2.3
+version: 0.2.4

--- a/charts/orchestrator-infra/README.md
+++ b/charts/orchestrator-infra/README.md
@@ -1,7 +1,7 @@
 
 # Orchestrator Infra Chart for OpenShift
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart to deploy the Orchestrator solution's required infrastructure suite on OpenShift, including OpenShift Serverless Operator and OpenShift Serverless Logic Operator, both required to configure Red Hat Developer Hub to use the Orchestrator.
@@ -25,7 +25,7 @@ Kubernetes: `>= 1.25.0-0`
 ```console
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.2.3
+helm install my-orchestrator-infra redhat-developer/redhat-developer-hub-orchestrator-infra --version 0.2.4
 ```
 
 > **Tip**: List all releases using `helm list`

--- a/charts/orchestrator-infra/templates/tests/infra-test.yaml
+++ b/charts/orchestrator-infra/templates/tests/infra-test.yaml
@@ -90,10 +90,10 @@ spec:
       resources:
         requests:
           cpu: 10m
-          memory: 20Mi
+          memory: 50Mi
         limits:
           cpu: 10m
-          memory: 20Mi
+          memory: 50Mi
       image: {{ .Values.tests.image }}
       command: ["/bin/sh", "-c"]
       args:


### PR DESCRIPTION
## Description of the change

Increase infra-test pod memory requests and limits from 20Mi to 50Mi
(cherry-picked from 0afb7da on `main`) to fix nightly CI failures on `release-1.8`,
and bump the orchestrator-infra chart version to 0.2.4.

## Which issue(s) does this PR fix or relate to

- https://github.com/redhat-developer/rhdh-chart/actions/runs/26605391486/job/78399162214

## How to test changes / Special notes to the reviewer

Run the nightly orchestrator-infra tests on `release-1.8` and verify the infra-test pod
no longer gets OOMKilled.

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [x] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file.