### PR TITLE
fix(orchestrator): use versioned name for the DB creation Job to avoid immutable upgrade errors (1.10.1)

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.3
+version: 5.12.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.3](https://img.shields.io/badge/Version-5.12.3-informational?style=flat-square)
+![Version: 5.12.4](https://img.shields.io/badge/Version-5.12.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.3
+helm install my-backstage redhat-developer/backstage --version 5.12.4
 ```
 
 ## Introduction

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -85,7 +85,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-create-sonataflow-database
+  name: {{ .Release.Name }}-create-sf-db-{{ .Chart.Version | replace "." "-" }}
   namespace: {{ .Release.Namespace }}
 spec:
   activeDeadlineSeconds: 120


### PR DESCRIPTION
## Description of the change

Backports **only the versioned Job-name change** from #407 to `release-1.10` (targets **1.10.1**).

The orchestrator DB-creation Job uses a fixed name `<release>-create-sonataflow-database` across chart versions. When any field of the rendered pod spec changes between versions — in practice the pinned **PostgreSQL image digest** — an in-place `helm upgrade` of an Orchestrator-enabled release tries to patch the Job's immutable `spec.template` and fails:

```
Error: UPGRADE FAILED: Job.batch "<release>-create-sonataflow-database" is invalid:
spec.template: Invalid value: { ... }: field is immutable
```

This is latent: the Job template itself is unchanged between 1.9 and 1.10 — the only differing field is the postgres image digest, so it can affect any upgrade where that digest bumps.

Using a versioned name `<release>-create-sf-db-<chart-version>` gives each chart version a distinct Job (recreated instead of patched), avoiding the immutable-field error.

### Scope

Per discussion, this intentionally includes **only** the versioned-name change. The fail-hard / configurable `backoffLimit` / TTL changes from #407 ([RHDHBUGS-2577](https://redhat.atlassian.net/browse/RHDHBUGS-2577)) are **left out** of the 1.10 line on purpose, so `activeDeadlineSeconds`, `backoffLimit` and the psql command are unchanged.

## How was the change tested?

- `helm template` with `orchestrator.enabled=true` renders the Job as `<release>-create-sf-db-5-12-4`.
- Reproduced the original immutable-Job failure on an in-place RHDH 1.9.3 -> 1.10 upgrade with Orchestrator enabled; the versioned name avoids it.

## Related

- Minimal backport of #407 (versioned-name part only)
- Fixes [RHDHBUGS-3325](https://redhat.atlassian.net/browse/RHDHBUGS-3325)
- Found during test [RHIDP-13211](https://redhat.atlassian.net/browse/RHIDP-13211) (v1.10 Orchestrator Plugins migration upgrade path)