### PR TITLE
[Release-1.10] update Lightspeed RAG image with 1.10 build

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.3
+version: 5.12.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.3](https://img.shields.io/badge/Version-5.12.3-informational?style=flat-square)
+![Version: 5.12.4](https://img.shields.io/badge/Version-5.12.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.3
+helm install my-backstage redhat-developer/backstage --version 5.12.4
 ```
 
 ## Introduction

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -186,7 +186,7 @@ Kubernetes: `>= 1.27.0-0`
 | global.lightspeed.configMaps[2].nameOverride | Name of an existing ConfigMap to use instead. Required when `create` is false. | string | `""` |
 | global.lightspeed.configMaps[2].sourceFile | Bundled file used to populate the ConfigMap data when `create` is true. | string | `"rhdh-profile.py"` |
 | global.lightspeed.enabled | Enable or disable the built-in Lightspeed feature. | bool | `true` |
-| global.lightspeed.initContainer.image | Full image reference for the Lightspeed RAG bootstrap init container. Override for disconnected environments. | string | `"quay.io/redhat-ai-dev/rag-content:release-1.9-lls-0.5.0-642c567fe10a62b5ff711654306b72912f341e05"` |
+| global.lightspeed.initContainer.image | Full image reference for the Lightspeed RAG bootstrap init container. Override for disconnected environments. | string | `"quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0-8c231a3b5177f12fff9db042dfa4091d8f2f26b3"` |
 | global.lightspeed.initContainer.resources | Resource requests/limits for the Lightspeed RAG bootstrap init container. | object | `{"limits":{"cpu":"100m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"150Mi"}}` |
 | global.lightspeed.plugins | Lightspeed plugins and their configuration. Override package references for disconnected environments. | list | `[{"disabled":false,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ \"{{inherit}}\" }}"},{"disabled":false,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ \"{{inherit}}\" }}"}]` |
 | global.lightspeed.ragVolume.emptyDir | `emptyDir` configuration for the RAG data volume. | object | `{}` |

--- a/charts/backstage/files/lightspeed/config.yaml
+++ b/charts/backstage/files/lightspeed/config.yaml
@@ -160,7 +160,7 @@ storage:
       db_path: /tmp/sql_store.db
     kv_rag:
       type: kv_sqlite
-      db_path: /rag-content/vector_db/rhdh_product_docs/1.9/faiss_store.db
+      db_path: /rag-content/vector_db/rhdh_product_docs/1.10/faiss_store.db
     kv_notebooks:
       type: kv_sqlite
       db_path: /rag-content/vector_db/notebooks/faiss_store.db
@@ -188,7 +188,7 @@ registered_resources:
     - provider_id: rag-runtime
       toolgroup_id: builtin::rag
   vector_stores:
-    - vector_store_id: vs_cda156a6-64fe-436d-bc51-566fb1b09702 # see readme for this value
+    - vector_store_id: vs_757285d9-b657-4bed-b18c-3359844e8c0d # see readme for this value
       embedding_model: sentence-transformers//rag-content/embeddings_model
       embedding_dimension: 768
       provider_id: rhdh-docs

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -192,7 +192,7 @@
                                 "-c"
                             ],
                             "env": [],
-                            "image": "quay.io/redhat-ai-dev/rag-content:release-1.9-lls-0.5.0-642c567fe10a62b5ff711654306b72912f341e05",
+                            "image": "quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0-8c231a3b5177f12fff9db042dfa4091d8f2f26b3",
                             "imagePullPolicy": "IfNotPresent",
                             "name": "lightspeed-rag-init",
                             "resources": {

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -126,7 +126,7 @@ global:
     initContainer:
       name: lightspeed-rag-init
       # -- Full image reference for the Lightspeed RAG bootstrap init container. Override for disconnected environments.
-      image: quay.io/redhat-ai-dev/rag-content:release-1.9-lls-0.5.0-642c567fe10a62b5ff711654306b72912f341e05
+      image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0-8c231a3b5177f12fff9db042dfa4091d8f2f26b3
       imagePullPolicy: IfNotPresent
       command:
         - sh


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change
- Updates the RAG image to the 1.10 build from Quay (replaced with product image in midstream)

<!-- Describe the change being requested. -->

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- _JIRA_issue_link_

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
