### PR TITLE
ci(nightly): fall back to `rhdh-hub-rhel9` when `next-1.y` tag expires

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,15 +69,24 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Compute image tag
+      - name: Compute image repo and tag
         if: steps.check.outputs.exists == 'true'
         id: image
         run: |
           if [[ "${{ matrix.branch }}" == "main" ]]; then
+            echo "repo=rhdh-community/rhdh" >> "$GITHUB_OUTPUT"
             echo "tag=next" >> "$GITHUB_OUTPUT"
           else
-            # release-x.y -> next-x.y
-            echo "tag=next-${BRANCH#release-}" >> "$GITHUB_OUTPUT"
+            version="${BRANCH#release-}"
+            candidate_tag="next-${version}"
+            if skopeo inspect --no-tags "docker://quay.io/rhdh-community/rhdh:${candidate_tag}" &>/dev/null; then
+              echo "repo=rhdh-community/rhdh" >> "$GITHUB_OUTPUT"
+              echo "tag=${candidate_tag}" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Tag ${candidate_tag} not found on quay.io/rhdh-community/rhdh, falling back to quay.io/rhdh/rhdh-hub-rhel9:${version}"
+              echo "repo=rhdh/rhdh-hub-rhel9" >> "$GITHUB_OUTPUT"
+              echo "tag=${version}" >> "$GITHUB_OUTPUT"
+            fi
           fi
         env:
           BRANCH: ${{ matrix.branch }}
@@ -107,4 +116,4 @@ jobs:
           chart: charts/${{ matrix.chart }}
           all_charts: 'true'
           monitoring_heartbeat: ${{ vars.TEST_MONITORING_HEARTBEAT_ENABLED || 'false' }}
-          extra_helm_args: ${{ matrix.chart == 'backstage' && format('--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag={0} --set upstream.backstage.image.pullPolicy=Always', steps.image.outputs.tag) || '' }}
+          extra_helm_args: ${{ matrix.chart == 'backstage' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1} --set upstream.backstage.image.pullPolicy=Always', steps.image.outputs.repo, steps.image.outputs.tag) || '' }}


### PR DESCRIPTION
## Description of the change

The `next-1.y` tags on `quay.io/rhdh-community/rhdh` can expire (e.g., `next-1.8` is already gone), causing the nightly workflow to fail for older release branches.

This updates the nightly workflow to use `skopeo inspect` at runtime to check whether `next-1.y` still exists. If the tag has expired, it falls back to `quay.io/rhdh/rhdh-hub-rhel9:1.y` instead.

This is a general-purpose fix — future tag expirations will be handled automatically without workflow edits.

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-chart/actions/runs/27792983781/job/82246295904#step:6:3711

## How to test changes / Special notes to the reviewer
&mdash;

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.