### PR TITLE
backport 1.10 - fix(lightspeed): pre-create /rag-content/vector_db/notebooks in init …

### DIFF
--- a/.github/actions/test-charts/action.yml
+++ b/.github/actions/test-charts/action.yml
@@ -166,8 +166,6 @@ runs:
           "--set route.enabled=false"
           "--set upstream.ingress.enabled=true"
           "--set global.host=rhdh.127.0.0.1.sslip.io"
-          "--set upstream.backstage.podSecurityContext.runAsUser=1001"
-          "--set upstream.backstage.podSecurityContext.runAsGroup=1001"
           "--set upstream.backstage.podSecurityContext.fsGroup=1001"
         )
         if [[ -n "$INPUT_EXTRA_HELM_ARGS" ]]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: helm-dependency-update
         name: helm-dependency-update
         entry: helm dependency update charts/backstage/vendor/backstage/charts/backstage
-        language: unsupported
+        language: system
         pass_filenames: false
         files: charts/backstage/vendor/backstage/charts/backstage/Chart\.(ya?ml|lock)$
       - id: jsonschema-dereference

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: helm-dependency-update
         name: helm-dependency-update
         entry: helm dependency update charts/backstage/vendor/backstage/charts/backstage
-        language: system
+        language: unsupported
         pass_filenames: false
         files: charts/backstage/vendor/backstage/charts/backstage/Chart\.(ya?ml|lock)$
       - id: jsonschema-dereference

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.4
+version: 5.12.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.4](https://img.shields.io/badge/Version-5.12.4-informational?style=flat-square)
+![Version: 5.12.5](https://img.shields.io/badge/Version-5.12.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.4
+helm install my-backstage redhat-developer/backstage --version 5.12.5
 ```
 
 ## Introduction

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -185,7 +185,7 @@
                         "enabled": true,
                         "initContainer": {
                             "args": [
-                                "mkdir -p /tmp/data && echo 'Copying Lightspeed RAG data...' && cp -r /rag/vector_db /rag-content/ && cp -r /rag/embeddings_model /rag-content/ && echo 'Copy complete.'"
+                                "mkdir -p /tmp/data && echo 'Copying Lightspeed RAG data...' && cp -r --no-preserve=mode,ownership /rag/vector_db /rag-content/ && cp -r --no-preserve=mode,ownership /rag/embeddings_model /rag-content/ && mkdir -p /rag-content/vector_db/notebooks && chmod -R a+rwX /rag-content/embeddings_model /rag-content/vector_db && echo 'Copy complete.'"
                             ],
                             "command": [
                                 "sh",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -135,8 +135,10 @@ global:
         - >-
           mkdir -p /tmp/data &&
           echo 'Copying Lightspeed RAG data...' &&
-          cp -r /rag/vector_db /rag-content/ &&
-          cp -r /rag/embeddings_model /rag-content/ &&
+          cp -r --no-preserve=mode,ownership /rag/vector_db /rag-content/ &&
+          cp -r --no-preserve=mode,ownership /rag/embeddings_model /rag-content/ &&
+          mkdir -p /rag-content/vector_db/notebooks &&
+          chmod -R a+rwX /rag-content/embeddings_model /rag-content/vector_db &&
           echo 'Copy complete.'
       env: []
       # -- Resource requests/limits for the Lightspeed RAG bootstrap init container.


### PR DESCRIPTION
…container

On EKS/AKS, the RAG init container populates /rag-content/ but never creates the notebooks subdirectory. At runtime, llama-stack tries to write /rag-content/vector_db/notebooks/faiss_store.db and fails with PermissionError because it cannot create the directory on a volume it doesn't own. OCP avoids this via fsGroup/supplemental group defaults.

The fix pre-creates the directory and widens permissions before the sidecar starts, matching the fix the operator already applies via chmod -R 777 for the rest of vector_db.

Fixes: [RHDHBUGS-3371](https://redhat.atlassian.net/browse/RHDHBUGS-3371)

<img width="768" height="328" alt="Screenshot From 2026-06-29 00-20-46" src="https://github.com/user-attachments/assets/ee5795ea-a457-4969-8fbf-8b5d2aee79c0" />

ran and verified on kind

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

<!-- Describe the change being requested. -->

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- _JIRA_issue_link_: [RHDHBUGS-3371](https://redhat.atlassian.net/browse/RHDHBUGS-3371)

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
