### PR TITLE
Lightspeed Core Service 0.5.2

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.5
+version: 5.12.6

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.4
+version: 5.12.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.4](https://img.shields.io/badge/Version-5.12.4-informational?style=flat-square)
+![Version: 5.12.5](https://img.shields.io/badge/Version-5.12.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.4
+helm install my-backstage redhat-developer/backstage --version 5.12.5
 ```
 
 ## Introduction
@@ -202,7 +202,7 @@ Kubernetes: `>= 1.27.0-0`
 | global.lightspeed.secret.name | Name of an existing Secret to use instead. Required when `create` is false. | string | `""` |
 | global.lightspeed.secret.optional | Whether the Secret reference is optional in the pod spec. | bool | `false` |
 | global.lightspeed.secret.sourceFile | Bundled file used to populate the Secret's `stringData` keys. | string | `"secret.yaml"` |
-| global.lightspeed.sidecar.image | Full image reference for the Lightspeed Core sidecar. Override for disconnected environments. | string | `"quay.io/lightspeed-core/lightspeed-stack:0.5.1"` |
+| global.lightspeed.sidecar.image | Full image reference for the Lightspeed Core sidecar. Override for disconnected environments. | string | `"quay.io/lightspeed-core/lightspeed-stack:0.5.2"` |
 | global.lightspeed.sidecar.resources | Resource requests/limits for the Lightspeed Core sidecar. | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"100m","memory":"512Mi"}}` |
 | nameOverride |  | string | `"developer-hub"` |
 | orchestrator.enabled |  | bool | `false` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.5](https://img.shields.io/badge/Version-5.12.5-informational?style=flat-square)
+![Version: 5.12.6](https://img.shields.io/badge/Version-5.12.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.5
+helm install my-backstage redhat-developer/backstage --version 5.12.6
 ```
 
 ## Introduction

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -253,7 +253,7 @@
                             "command": [],
                             "containerPort": 8080,
                             "env": [],
-                            "image": "quay.io/lightspeed-core/lightspeed-stack:0.5.1",
+                            "image": "quay.io/lightspeed-core/lightspeed-stack:0.5.2",
                             "imagePullPolicy": "IfNotPresent",
                             "name": "lightspeed-core",
                             "portName": "http-lightspeed",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -159,7 +159,7 @@ global:
     sidecar:
       name: lightspeed-core
       # -- Full image reference for the Lightspeed Core sidecar. Override for disconnected environments.
-      image: quay.io/lightspeed-core/lightspeed-stack:0.5.1
+      image: quay.io/lightspeed-core/lightspeed-stack:0.5.2
       imagePullPolicy: IfNotPresent
       portName: http-lightspeed
       containerPort: 8080


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

Patches Lightspeed Core Service (or Lightspeed Stack) to use v0.5.2.

## Which issue(s) does this PR fix or relate to

- https://redhat.atlassian.net/browse/RHIDP-14724

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
