### PR TITLE
[release-1.10] fix(orchestrator): lowercase and truncate DB creation Job name for compliance [RHDHBUGS-3450]

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.12.6
+version: 5.12.7

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.12.6](https://img.shields.io/badge/Version-5.12.6-informational?style=flat-square)
+![Version: 5.12.7](https://img.shields.io/badge/Version-5.12.7-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -29,7 +29,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.12.6
+helm install my-backstage redhat-developer/backstage --version 5.12.7
 ```
 
 ## Introduction

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -332,6 +332,16 @@ images are configured.
 {{- end -}}
 
 {{/*
+Returns the orchestrator DB creation Job name, lowercased and truncated to 63 chars.
+The version suffix is preserved in full; only the prefix is truncated.
+*/}}
+{{- define "rhdh.orchestrator.dbJobName" -}}
+{{- $versionSuffix := printf "-%s" (.Chart.Version | replace "." "-") -}}
+{{- $prefix := printf "%s-create-sf-db" .Release.Name | trunc (int (sub 63 (len $versionSuffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $prefix $versionSuffix | lower -}}
+{{- end -}}
+
+{{/*
 DEPRECATED: The following templates are deprecated. Please use the corresponding "rhdh.*" templates instead.
 */}}
 

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -85,7 +85,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-create-sf-db-{{ .Chart.Version | replace "." "-" }}
+  name: {{ include "rhdh.orchestrator.dbJobName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   activeDeadlineSeconds: 120


### PR DESCRIPTION
## Description of the change

The versioned Job name introduced in e767157 (PR #427) embedded `.Chart.Version` into the orchestrator DB creation Job name without sanitizing it. Chart versions containing uppercase characters (e.g., `1.10-147-CI`) produce a Job name like `redhat-developer-hub-create-sf-db-1-10-147-CI`, which violates Kubernetes RFC 1123 subdomain naming rules.

## Which issue(s) does this PR fix or relate to

- [RHDHBUGS-3450](https://redhat.atlassian.net/browse/RHDHBUGS-3450)

## How to test changes / Special notes to the reviewer

A CI chart version should work properly once this is merged. Also, installing a very long release name should truncate to 63 chars with version suffix preserved.

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.