### PR TITLE
fix(RHDHBUGS-3464): lowercase metadata in the chart to resolve k8's RFC 1123 format.

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 6.2.0
+version: 6.2.1

--- a/charts/backstage/templates/sonataflows.yaml
+++ b/charts/backstage/templates/sonataflows.yaml
@@ -85,7 +85,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-create-sf-db-{{ .Chart.Version | replace "." "-" }}
+  name: {{ .Release.Name }}-create-sf-db-{{ .Chart.Version | replace "." "-" | lower }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- with .Values.orchestrator.sonataflowPlatform.dbCreationJobTTLSecondsAfterFinished }}


### PR DESCRIPTION
Signed-off-by: skestwal <skestwal@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

In case of the .Chart.Version not a lower case value the job failed. The uppercase values violates Kubernetes DNS subdomain naming rules (RFC 1123). The API server rejects the Job, so it is never created.

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->
- [RHDHBUGS-3464](https://redhat.atlassian.net/browse/RHDHBUGS-3464)

## How to test changes / Special notes to the reviewer


## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
