### PR TITLE
[release-1.10] ci: re-add `--upgrade` option to `ct` args

### DIFF
--- a/.github/actions/test-charts/action.yml
+++ b/.github/actions/test-charts/action.yml
@@ -199,6 +199,7 @@ runs:
         fi
         CT_ARGS=(
           --config ct-install.yaml
+          --upgrade
           --target-branch "$INPUT_TARGET_BRANCH"
           --helm-extra-set-args="${EXTRA_ARGS[*]}"
         )


### PR DESCRIPTION
Followup to https://github.com/redhat-developer/rhdh-chart/pull/482
To test in-place upgrades.
