### PR TITLE
ci: auto-commit pre-commit fixes on same-repo PRs

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -48,6 +48,7 @@ jobs:
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
       - name: Run pre-commit
+        id: precommit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         continue-on-error: true
         with:
@@ -89,10 +90,18 @@ jobs:
             git reset --mixed HEAD~1
           fi
 
-      - name: Fail if pre-commit changes are not committed
-        if: steps.check.outputs.changed == 'true' && steps.autopush.outputs.pushed != 'true'
+      - name: Re-run pre-commit after auto-push
+        if: steps.autopush.outputs.pushed == 'true'
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --verbose --all-files --show-diff-on-failure
+
+      - name: Fail if pre-commit issues remain
+        if: >-
+          steps.precommit.outcome == 'failure' &&
+          (steps.check.outputs.changed != 'true' || steps.autopush.outputs.pushed != 'true')
         run: |
-          echo "::error::Pre-commit hooks modified files that need to be committed"
+          echo "::error::Pre-commit hooks detected issues that need to be fixed"
           echo ""
           echo "❌ The pre-commit hooks detected issues that need to be fixed."
           echo ""

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,8 +18,6 @@ jobs:
   pre-commit:
     name: Pre-commit
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     env:
       GO111MODULE: on
     steps:
@@ -57,11 +55,12 @@ jobs:
       - name: Check for changes
         id: check
         run: |
-          if git diff --quiet; then
+          if [[ -z "$(git status --porcelain)" ]]; then
             echo "✅ All files are up to date"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "Pre-commit hooks modified files"
+            git status --short
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,14 +18,18 @@ jobs:
   pre-commit:
     name: Pre-commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GO111MODULE: on
     steps:
-      - name: Checkout
+      - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
           fetch-depth: 0
-          persist-credentials: false # Avoid token leakage to hooks
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -45,5 +49,56 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        continue-on-error: true
         with:
           extra_args: --verbose --all-files --show-diff-on-failure
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "✅ All files are up to date"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-commit hooks modified files"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Auto-commit and push pre-commit changes
+        id: autopush
+        # Only attempt on same-repo PRs (not forks) for security; best-effort — failure falls through to the next step
+        if: steps.check.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        env:
+          RHDH_BOT_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ -z "${RHDH_BOT_TOKEN}" || -z "${HEAD_REF}" ]]; then
+            echo "::warning::RHDH_BOT_TOKEN or HEAD_REF is not set, skipping auto-push"
+            exit 0
+          fi
+          git config user.name "rhdh-bot"
+          git config user.email "rhdh-bot@redhat.com"
+          git remote set-url origin "https://x-access-token:${RHDH_BOT_TOKEN}@github.com/${{ github.repository }}.git"
+          git add -A
+          git commit -m "chore: apply pre-commit fixes"
+          if git push origin "HEAD:${HEAD_REF}"; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            git reset --mixed HEAD~1
+          fi
+
+      - name: Fail if pre-commit changes are not committed
+        if: steps.check.outputs.changed == 'true' && steps.autopush.outputs.pushed != 'true'
+        run: |
+          echo "::error::Pre-commit hooks modified files that need to be committed"
+          echo ""
+          echo "❌ The pre-commit hooks detected issues that need to be fixed."
+          echo ""
+          echo "To fix these issues:"
+          echo "  1. Install pre-commit: https://pre-commit.com/#install"
+          echo "  2. Install helm-docs: https://github.com/norwoodj/helm-docs#installation"
+          echo "  3. Run: pre-commit run --all-files"
+          echo "  4. Commit and push any resulting changes"
+          exit 1


### PR DESCRIPTION
## Description of the change

Similar to https://github.com/redhat-developer/rhdh-operator/pull/3228 for the Operator, this auto-commits and pushes pre-commit hook changes for same-repo PRs using the `rhdh-bot` token, reducing friction for maintainers, especially when reviewing PRs from Renovate in the same repo.

For fork PRs, the existing behavior is preserved: the workflow fails and a comment is posted.

## Which issue(s) does this PR fix or relate to

- https://github.com/redhat-developer/rhdh-chart/actions/runs/29439312615/job/87433880047?pr=472

## How to test changes / Special notes to the reviewer

- **Same-repo PR**: if pre-commit hooks modify files, `rhdh-bot` auto-commits and pushes the fixes; workflow passes.
- **Fork PR with changes**: auto-push step is skipped, workflow fails, and the existing `pre-commit-comment.yaml` workflow posts a comment.
- **Missing `RHDH_BOT_TOKEN` or push failure**: workflow fails gracefully with the existing error message.

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/). N/A — CI-only change.
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. N/A — CI-only change.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook. N/A — CI-only change.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command. N/A — CI-only change.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. N/A — CI-only change.