### PR TITLE
[release-1.9] ci(backstage): skip plugin downloads in PR checks and use chart defaults

### DIFF
--- a/.github/actions/test-charts/action.yml
+++ b/.github/actions/test-charts/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: 'Install all charts instead of only changed ones'
     required: false
     default: 'false'
+  helm_extra_args:
+    description: 'Extra arguments to pass to helm via ct install --helm-extra-args (e.g., --values file.yaml)'
+    required: false
+    default: ''
+  helm_template_values_file:
+    description: 'Extra values file for a helm-template sanity check (renders each CI scenario with these values layered on top, but does not install)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -71,6 +79,22 @@ runs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add backstage https://backstage.github.io/charts
         helm repo update
+
+    - name: Helm template sanity check (full-plugins override)
+      if: (steps.list-changed.outputs.backstageChartChanged == 'true' || inputs.all_charts == 'true') && inputs.helm_template_values_file != ''
+      shell: bash
+      env:
+        VALUES_FILE: ${{ inputs.helm_template_values_file }}
+      run: |
+        helm dependency build charts/backstage
+        for ci_values in charts/backstage/ci/*-values.yaml; do
+          [[ -f "$ci_values" ]] || continue
+          echo "==> helm template: $(basename "$ci_values") + $(basename "$VALUES_FILE")"
+          output=$(helm template test-release charts/backstage \
+            --kube-version 1.30.0 \
+            --values "$ci_values" \
+            --values "$VALUES_FILE" 2>&1) || { echo "$output"; exit 1; }
+        done
 
     - name: Generate KinD Config
       if: steps.list-changed.outputs.changed == 'true'
@@ -135,7 +159,7 @@ runs:
       env:
         OLM_VERSION: "v0.31.0"
       run: |
-        curl -L "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh" -o install-olm.sh
+        curl --proto =https -L "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh" -o install-olm.sh
         chmod +x install-olm.sh
         ./install-olm.sh "${OLM_VERSION}"
 
@@ -160,6 +184,7 @@ runs:
       shell: bash
       env:
         INPUT_EXTRA_HELM_ARGS: ${{ inputs.extra_helm_args }}
+        INPUT_HELM_EXTRA_ARGS: ${{ inputs.helm_extra_args }}
         INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
         INPUT_ALL_CHARTS: ${{ inputs.all_charts }}
       run: |
@@ -173,12 +198,17 @@ runs:
           EXTRA_ARGS+=("${ADDITIONAL_ARGS[@]}")
         fi
         CT_ARGS=(
-          --debug
           --config ct-install.yaml
           --upgrade
           --target-branch "$INPUT_TARGET_BRANCH"
           --helm-extra-set-args="${EXTRA_ARGS[*]}"
         )
+        if [[ "$RUNNER_DEBUG" == "1" ]]; then
+          CT_ARGS+=(--debug)
+        fi
+        if [[ -n "$INPUT_HELM_EXTRA_ARGS" ]]; then
+          CT_ARGS+=(--helm-extra-args="$INPUT_HELM_EXTRA_ARGS")
+        fi
         if [[ "$INPUT_ALL_CHARTS" == "true" ]]; then
           CT_ARGS+=(--all)
         fi

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,9 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate nightly values override for backstage chart
+        run: |
+          yq e '{"global": {"dynamic": {"includes": .global.dynamic.includes}}, "orchestrator": {"plugins": .orchestrator.plugins}}' \
+            charts/backstage/values.yaml > /tmp/backstage-nightly-values.yaml
+
       - name: Test charts
         uses: ./.github/actions/test-charts
         with:
           target_branch: main
           all_charts: 'true'
           extra_helm_args: '--set upstream.backstage.image.repository=rhdh-community/rhdh --set upstream.backstage.image.tag=next --set upstream.backstage.image.pullPolicy=Always'
+          helm_extra_args: '--values /tmp/backstage-nightly-values.yaml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,7 @@ jobs:
     # Aligning job name with the OpenShift CI config: https://github.com/openshift/release/blob/master/core-services/prow/02_config/redhat-developer/rhdh-chart/_prowconfig.yaml#L18
     name: Test Latest Release
     runs-on: ubuntu-latest
-    # Make CI for PRs more stable by using the latest stable/RC RHDH image.
-    # We have a workflow that tests the unstable 'next' image tag on a nightly basis.
-    # Image repository and tag can be configured via GitHub repository variables.
-    env:
-      RHDH_IMAGE_REPOSITORY: ${{ vars.RHDH_IMAGE_REPOSITORY || 'rhdh/rhdh-hub-rhel9' }}
-      RHDH_IMAGE_TAG: ${{ vars.RHDH_IMAGE_TAG || 'latest' }}
+    timeout-minutes: 120
 
     steps:
       - name: Checkout
@@ -29,9 +24,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate full-plugins values for template sanity check
+        run: |
+          yq e '{"global": {"dynamic": {"includes": .global.dynamic.includes}}, "orchestrator": {"plugins": .orchestrator.plugins}}' \
+            charts/backstage/values.yaml > /tmp/backstage-full-plugins-values.yaml
+
       - name: Test charts
         uses: ./.github/actions/test-charts
         with:
           target_branch: ${{ github.event.pull_request.base.ref }}
-          # The RHDH image tag is already pinned to a specific version for the 'release-1.y' branches.
-          extra_helm_args: ${{ github.event.pull_request.base.ref == 'main' && format('--set upstream.backstage.image.repository={0} --set upstream.backstage.image.tag={1}', env.RHDH_IMAGE_REPOSITORY, env.RHDH_IMAGE_TAG) || '' }}
+          helm_template_values_file: /tmp/backstage-full-plugins-values.yaml

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -47,4 +47,4 @@ sources: []
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 5.0.3
+version: 5.0.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Backstage Helm Chart for OpenShift
 
-![Version: 5.0.3](https://img.shields.io/badge/Version-5.0.3-informational?style=flat-square)
+![Version: 5.0.4](https://img.shields.io/badge/Version-5.0.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -30,7 +30,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add backstage https://backstage.github.io/charts
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-backstage redhat-developer/backstage --version 5.0.3
+helm install my-backstage redhat-developer/backstage --version 5.0.4
 ```
 
 ## Introduction

--- a/charts/backstage/ci/default-values.yaml
+++ b/charts/backstage/ci/default-values.yaml
@@ -1,6 +1,13 @@
 # Workaround for kind cluster in CI which has no Routes and no PVCs
 route:
   enabled: false
+
+# CI: skip dynamic plugin downloads to speed up tests.
+# The chart features under test (deployment, config, probes, etc.) don't depend on actual plugins.
+global:
+  dynamic:
+    includes: []
+
 upstream:
   postgresql:
     primary:

--- a/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
+++ b/charts/backstage/ci/with-custom-dynamic-pvc-claim-spec-values.yaml
@@ -2,6 +2,11 @@
 route:
   enabled: false
 
+# CI: skip dynamic plugin downloads to speed up tests.
+global:
+  dynamic:
+    includes: []
+
 upstream:
   postgresql:
     primary:

--- a/charts/backstage/ci/with-custom-image-for-test-pod-values.yaml
+++ b/charts/backstage/ci/with-custom-image-for-test-pod-values.yaml
@@ -1,6 +1,12 @@
 # Workaround for kind cluster in CI which has no Routes and no PVCs
 route:
   enabled: false
+
+# CI: skip dynamic plugin downloads to speed up tests.
+global:
+  dynamic:
+    includes: []
+
 upstream:
   postgresql:
     primary:

--- a/charts/backstage/ci/with-orchestrator-and-dynamic-plugins-npmrc-values.yaml
+++ b/charts/backstage/ci/with-orchestrator-and-dynamic-plugins-npmrc-values.yaml
@@ -9,6 +9,8 @@ upstream:
 
 global:
   dynamic:
+    # CI: skip dynamic plugin downloads to speed up tests.
+    includes: []
     plugins:
       # Enable additional plugins, which should be merged with the Orchestrator plugins
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
@@ -18,6 +20,7 @@ global:
 
 orchestrator:
   enabled: true
+  plugins: []
 
 test:
   injectTestNpmrcSecret: true

--- a/charts/backstage/ci/with-orchestrator-values.yaml
+++ b/charts/backstage/ci/with-orchestrator-values.yaml
@@ -9,6 +9,8 @@ upstream:
 
 global:
   dynamic:
+    # CI: skip dynamic plugin downloads to speed up tests.
+    includes: []
     plugins:
       # Enable additional plugins, which should be merged with the Orchestrator plugins
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
@@ -18,3 +20,4 @@ global:
 
 orchestrator:
   enabled: true
+  plugins: []

--- a/charts/backstage/ci/with-test-pod-disabled-values.yaml
+++ b/charts/backstage/ci/with-test-pod-disabled-values.yaml
@@ -1,6 +1,12 @@
 # Workaround for kind cluster in CI which has no Routes and no PVCs
 route:
   enabled: false
+
+# CI: skip dynamic plugin downloads to speed up tests.
+global:
+  dynamic:
+    includes: []
+
 upstream:
   postgresql:
     primary:


### PR DESCRIPTION
manual cherry-pick of #482
