### PR TITLE
chore(hardening): move RHDH_GITHUB_APP_ID to...

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -78,7 +78,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
-          app_id: ${{ vars.RHDH_GITHUB_APP_ID }}
+          app_id: ${{ secrets.RHDH_GITHUB_APP_ID }}
           private_key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Repository


### PR DESCRIPTION
### What does this PR do?

chore(hardening): move RHDH_GITHUB_APP_ID to secrets for consistency and security

Signed-off-by: Nick Boldt <nboldt@redhat.com>

Related to clean up work for https://redhat.atlassian.net/browse/RHIDP-16167 

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.