### PR TITLE
chore: exclude deprecated and demo-only charts from Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
     "helpers:pinGitHubActionDigests"
   ],
   "ignorePaths": [
-    "charts/**/vendor/**"
+    "charts/**/vendor/**",
+    "charts/backstage/**",
+    "charts/orchestrator-software-templates/**",
+    "charts/orchestrator-software-templates-infra/**"
   ]
 }


### PR DESCRIPTION
## Description of the change

Add the deprecated `charts/backstage/` and demo-only `charts/orchestrator-software-templates{,-infra}/` paths to Renovate's `ignorePaths` so it stops creating dependency-update PRs for charts that are no longer actively maintained.

This avoids noise like #510.

## Which issue(s) does this PR fix or relate to

N/A

## How to test changes / Special notes to the reviewer

After merging, Renovate should no longer open PRs for files under the ignored chart paths. Existing open PRs from Renovate for those charts (e.g. #510) can be closed.

## Checklist

- [x] No Chart was updated — this only changes the Renovate configuration.