### PR TITLE
feat(rhdh): add lifecycleHooks, priorityClassName, terminationGracePeriodSeconds

### DIFF
--- a/charts/rhdh/Chart.yaml
+++ b/charts/rhdh/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: redhat-developer-hub
 type: application
-version: 1.0.2
+version: 1.1.0
 appVersion: 2.1.0
 annotations:
   artifacthub.io/category: integration-delivery

--- a/charts/rhdh/README.md
+++ b/charts/rhdh/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Helm Chart for OpenShift and Kubernetes
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -36,7 +36,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-rhdh redhat-developer/redhat-developer-hub --version 1.0.2
+helm install my-rhdh redhat-developer/redhat-developer-hub --version 1.1.0
 ```
 
 ## Introduction
@@ -243,6 +243,7 @@ Kubernetes: `>= 1.31.0-0`
 | image.digest | Overrides the image tag with an image digest. | string | `""` |
 | imagePullSecrets | Secrets for pulling images from private registries (merged with global.imagePullSecrets). | list | `[]` |
 | ingress | Kubernetes Ingress configuration. | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"{{ .Values.host }}","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` |
+| lifecycleHooks | Lifecycle hooks for the main RHDH container. Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ | object | `{}` |
 | lightspeed | Built-in Lightspeed AI feature configuration. | object | `{"config":{"profile":{"existingConfigMap":{"key":"","name":""}},"server":{"existingConfigMap":{"key":"","name":""}},"stack":{"existingConfigMap":{"key":"","name":""}}},"core":{"argsOverride":[],"commandOverride":[],"extraArgs":[],"extraEnv":[],"extraVolumeMounts":[],"image":{"digest":"","registry":"quay.io","repository":"lightspeed-core/lightspeed-stack","tag":"0.6.2"},"imagePullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"100m","memory":"512Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}},"enabled":true,"existingSecret":"","plugins":[{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ \"{{inherit}}\" }}"},{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ \"{{inherit}}\" }}"}],"ragInit":{"argsOverride":[],"commandOverride":[],"extraArgs":[],"extraEnv":[],"extraVolumeMounts":[],"image":{"digest":"","registry":"quay.io","repository":"redhat-ai-dev/rag-content","tag":"release-1.10-lls-0.5.0-8c231a3b5177f12fff9db042dfa4091d8f2f26b3"},"imagePullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"100m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"150Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}},"runtimeVolume":{"emptyDir":{},"persistentVolumeClaim":{},"type":"emptyDir"}}` |
 | lightspeed.config | Configuration files mounted into the sidecar. By default, the chart creates ConfigMaps from bundled source files. Set existingConfigMap to use a pre-existing ConfigMap instead. | object | `{"profile":{"existingConfigMap":{"key":"","name":""}},"server":{"existingConfigMap":{"key":"","name":""}},"stack":{"existingConfigMap":{"key":"","name":""}}}` |
 | lightspeed.config.profile | Python profile with prompt templates (rhdh-profile.py). | object | `{"existingConfigMap":{"key":"","name":""}}` |
@@ -294,6 +295,7 @@ Kubernetes: `>= 1.31.0-0`
 | podSecurityContext | Pod-level security context. | object | `{}` |
 | postgresql | Built-in PostgreSQL database (bitnami subchart). | object | `{"auth":{"secretKeys":{"adminPasswordKey":"postgres-password","userPasswordKey":"password"}},"enabled":true,"image":{"digest":"","registry":"quay.io","repository":"fedora/postgresql-15","tag":"latest"},"postgresqlDataDir":"/var/lib/pgsql/data/userdata","primary":{"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":false},"extraEnvVars":[{"name":"POSTGRESQL_ADMIN_PASSWORD","valueFrom":{"secretKeyRef":{"key":"{{- include \"rhdh.postgresql.adminPasswordKey\" . }}","name":"{{- include \"rhdh.postgresql.secretName\" . }}"}}}],"persistence":{"enabled":true,"mountPath":"/var/lib/pgsql/data","size":"1Gi"},"podSecurityContext":{"enabled":false},"resources":{"limits":{"cpu":"250m","ephemeral-storage":"20Mi","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}},"serviceBindings":{"enabled":true}}` |
 | preInitContainers | Init containers to run BEFORE the system init containers (e.g. inject auth credentials before install-dynamic-plugins runs). | list | `[]` |
+| priorityClassName | Priority class name for pod scheduling. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ | string | `""` |
 | readinessProbe | Readiness probe configuration. | object | `{"failureThreshold":3,"httpGet":{"path":"/.backstage/health/v1/readiness","port":"backend","scheme":"HTTP"},"periodSeconds":10,"successThreshold":2,"timeoutSeconds":4}` |
 | replicaCount | Number of desired pods. | int | `1` |
 | resources | Resource requests and limits for the main RHDH container. | object | `{"limits":{"cpu":"1000m","ephemeral-storage":"5Gi","memory":"2.5Gi"},"requests":{"cpu":"250m","memory":"1Gi"}}` |
@@ -308,6 +310,7 @@ Kubernetes: `>= 1.31.0-0`
 | serviceAccount.name | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | string | `""` |
 | startupProbe | Startup probe configuration. Gives the application time to start before liveness/readiness probes kick in. | object | `{"failureThreshold":3,"httpGet":{"path":"/.backstage/health/v1/liveness","port":"backend","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":4}` |
 | strategy | Deployment update strategy. | object | `{}` |
+| terminationGracePeriodSeconds | Duration in seconds the pod needs to terminate gracefully before being force killed. Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination | string | `nil` |
 | test | Test pod configuration for `helm test`. | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","registry":"quay.io","repository":"curl/curl","tag":"8.21.0"},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}}` |
 | tolerations | Tolerations for pod assignment. | list | `[]` |
 | topologySpreadConstraints | Topology spread constraints for pod scheduling. | list | `[]` |

--- a/charts/rhdh/templates/deployment.yaml
+++ b/charts/rhdh/templates/deployment.yaml
@@ -71,6 +71,12 @@ spec:
       hostAliases:
         {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- if not (kindIs "invalid" .Values.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
         # --- System volumes (hardcoded, never replaced) ---
         - name: dynamic-plugins-root
@@ -317,6 +323,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
+            {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycleHooks }}
+          lifecycle:
             {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.commandOverride }}

--- a/charts/rhdh/values.schema.json
+++ b/charts/rhdh/values.schema.json
@@ -714,6 +714,12 @@
             "title": "Kubernetes Ingress configuration.",
             "type": "object"
         },
+        "lifecycleHooks": {
+            "default": {},
+            "description": "Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/",
+            "title": "Lifecycle hooks for the main RHDH container.",
+            "type": "object"
+        },
         "lightspeed": {
             "additionalProperties": false,
             "default": {
@@ -2104,6 +2110,12 @@
             "title": "Init containers to run BEFORE the system init containers (e.g. inject auth credentials before install-dynamic-plugins runs).",
             "type": "array"
         },
+        "priorityClassName": {
+            "default": "",
+            "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/",
+            "title": "Priority class name for pod scheduling.",
+            "type": "string"
+        },
         "readinessProbe": {
             "default": {
                 "failureThreshold": 3,
@@ -2299,6 +2311,16 @@
             "default": {},
             "title": "Deployment update strategy.",
             "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+            "default": null,
+            "description": "Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+            "minimum": 0,
+            "title": "Duration in seconds the pod needs to terminate gracefully before being force killed.",
+            "type": [
+                "integer",
+                "null"
+            ]
         },
         "test": {
             "additionalProperties": false,

--- a/charts/rhdh/values.schema.tmpl.json
+++ b/charts/rhdh/values.schema.tmpl.json
@@ -392,6 +392,25 @@
             "type": "array",
             "default": []
         },
+        "priorityClassName": {
+            "title": "Priority class name for pod scheduling.",
+            "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/",
+            "type": "string",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "title": "Duration in seconds the pod needs to terminate gracefully before being force killed.",
+            "description": "Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+            "type": ["integer", "null"],
+            "default": null,
+            "minimum": 0
+        },
+        "lifecycleHooks": {
+            "title": "Lifecycle hooks for the main RHDH container.",
+            "description": "Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/",
+            "type": "object",
+            "default": {}
+        },
         "deploymentAnnotations": {
             "title": "Annotations for the Deployment resource (not the pod).",
             "type": "object",

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -312,6 +312,23 @@ topologySpreadConstraints: []
 # -- Host aliases for /etc/hosts entries.
 hostAliases: []
 
+# -- Priority class name for pod scheduling.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+priorityClassName: ""
+
+# -- Duration in seconds the pod needs to terminate gracefully before being force killed.
+# Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+# @default -- `nil`
+terminationGracePeriodSeconds:
+
+# -- Lifecycle hooks for the main RHDH container.
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycleHooks: {}
+# lifecycleHooks:
+#   preStop:
+#     exec:
+#       command: ["/bin/sh", "-c", "sleep 10"]
+
 # -- Annotations for the Deployment resource (not the pod).
 deploymentAnnotations: {}
 


### PR DESCRIPTION
## Description of the change

Replicate the `lifecycleHooks`, `priorityClassName`, and `terminationGracePeriodSeconds` fields recently added to the [upstream backstage chart](https://github.com/backstage/charts) into the standalone `charts/rhdh` chart. Noticed in https://github.com/redhat-developer/rhdh-chart/pull/499

- **`lifecycleHooks`** (container-level): Rendered as `lifecycle` on the main RHDH container. Supports `preStop`, `postStart`, etc.
- **`priorityClassName`** (pod-level): Allows setting a priority class for pod scheduling.
- **`terminationGracePeriodSeconds`** (pod-level): Configures the graceful shutdown window. Supports `0` (rendered) vs `null`/unset (omitted).

All three fields default to empty/null (matching upstream) and are omitted from the rendered manifest when not set.

## Which issue(s) does this PR fix or relate to

- Aligns with upstream backstage/charts changes (lifecycleHooks, priorityClassName, terminationGracePeriodSeconds)
- Supersedes #499 (which targets the deprecated `charts/backstage` chart)

## How to test changes / Special notes to the reviewer

```bash
# Default: none of the new fields appear
helm template test charts/rhdh | grep -E 'priorityClassName|terminationGrace|lifecycle:'

# With values set: all three fields render correctly
helm template test charts/rhdh \
  --set priorityClassName=high-priority \
  --set terminationGracePeriodSeconds=60 \
  --set 'lifecycleHooks.preStop.exec.command[0]=/bin/sh' \
  --set 'lifecycleHooks.preStop.exec.command[1]=-c' \
  --set 'lifecycleHooks.preStop.exec.command[2]=sleep 10'

# Edge case: terminationGracePeriodSeconds=0 renders (not treated as falsy)
helm template test charts/rhdh --set terminationGracePeriodSeconds=0 | grep terminationGrace
```

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [x] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.