### PR TITLE
feat(rhdh chart): Add option to specify RHDH route's targetPort

### DIFF
--- a/charts/rhdh/Chart.yaml
+++ b/charts/rhdh/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: redhat-developer-hub
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.1.0
 annotations:
   artifacthub.io/category: integration-delivery

--- a/charts/rhdh/README.md
+++ b/charts/rhdh/README.md
@@ -1,7 +1,7 @@
 
 # RHDH Helm Chart for OpenShift and Kubernetes
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Red Hat Developer Hub, which is a Red Hat supported version of Backstage.
@@ -36,7 +36,7 @@ For the **Generally Available** version of this chart, see:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
 
-helm install my-rhdh redhat-developer/redhat-developer-hub --version 2.1.0
+helm install my-rhdh redhat-developer/redhat-developer-hub --version 2.1.1
 ```
 
 ## Introduction
@@ -269,9 +269,9 @@ Kubernetes: `>= 1.31.0-0`
 | metrics | Prometheus metrics configuration. | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":"","labels":{},"path":"/metrics","port":"http-metrics"}}` |
 | nameOverride | Override the chart name used in resource naming. | string | `""` |
 | nodeSelector | Node labels for pod assignment. | object | `{}` |
-| openshift | OpenShift-specific configuration. | object | `{"clusterRouterBase":"apps.example.com","route":{"annotations":{},"enabled":true,"host":"{{ .Values.host }}","path":"/","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}}` |
+| openshift | OpenShift-specific configuration. | object | `{"clusterRouterBase":"apps.example.com","route":{"annotations":{},"enabled":true,"host":"{{ .Values.host }}","path":"/","targetPort":"http-backend","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}}` |
 | openshift.clusterRouterBase | Cluster router base domain used to auto-generate the hostname. | string | `"apps.example.com"` |
-| openshift.route | OpenShift Route configuration. | object | `{"annotations":{},"enabled":true,"host":"{{ .Values.host }}","path":"/","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}` |
+| openshift.route | OpenShift Route configuration. | object | `{"annotations":{},"enabled":true,"host":"{{ .Values.host }}","path":"/","targetPort":"http-backend","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}` |
 | orchestrator | Orchestrator (Serverless workflows) configuration. | object | `{"enabled":false,"plugins":[{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{ \"{{inherit}}\" }}"},{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{ \"{{inherit}}\" }}"},{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{ \"{{inherit}}\" }}"},{"enabled":true,"package":"oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{ \"{{inherit}}\" }}"}],"serverlessLogicOperator":{"enabled":true},"serverlessOperator":{"enabled":true},"sonataflowPlatform":{"dataIndex":{"image":{"digest":"","registry":"","repository":"","tag":""}},"dbCreationJob":{"activeDeadlineSeconds":120,"backoffLimit":2,"image":{"digest":"{{ .Values.postgresql.image.digest }}","registry":"{{ .Values.postgresql.image.registry }}","repository":"{{ .Values.postgresql.image.repository }}","tag":"{{ .Values.postgresql.image.tag }}"},"ttlSecondsAfterFinished":null},"eventing":{"broker":{"name":"","namespace":""}},"externalDB":{"existingSecret":"","host":"","name":"","port":""},"jobService":{"image":{"digest":"","registry":"","repository":"","tag":""}},"monitoring":{"enabled":true},"resources":{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"64Mi"}}}}` |
 | orchestrator.sonataflowPlatform.dataIndex | SonataFlow Data Index service configuration. | object | `{"image":{"digest":"","registry":"","repository":"","tag":""}}` |
 | orchestrator.sonataflowPlatform.dataIndex.image | Override the Data Index container image. If empty, the operator default is used. | object | `{"digest":"","registry":"","repository":"","tag":""}` |

--- a/charts/rhdh/templates/route.yaml
+++ b/charts/rhdh/templates/route.yaml
@@ -25,7 +25,7 @@ spec:
   path: {{ . }}
 {{- end }}
   port:
-    targetPort: http-backend
+    targetPort: {{ .Values.openshift.route.targetPort }}
 {{- if .Values.openshift.route.tls.enabled }}
   tls:
     insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}

--- a/charts/rhdh/values.schema.json
+++ b/charts/rhdh/values.schema.json
@@ -1660,6 +1660,11 @@
                             "title": "Path that the router watches for, to route traffic for to the service.",
                             "type": "string"
                         },
+                        "targetPort": {
+                            "default": "http-backend",
+                            "title": "targetPort",
+                            "type": "string"
+                        },
                         "tls": {
                             "additionalProperties": false,
                             "properties": {

--- a/charts/rhdh/values.schema.json
+++ b/charts/rhdh/values.schema.json
@@ -1662,7 +1662,7 @@
                         },
                         "targetPort": {
                             "default": "http-backend",
-                            "title": "targetPort",
+                            "title": "Target port of the service to route traffic to.",
                             "type": "string"
                         },
                         "tls": {

--- a/charts/rhdh/values.schema.tmpl.json
+++ b/charts/rhdh/values.schema.tmpl.json
@@ -1026,6 +1026,11 @@
                             "type": "string",
                             "default": "/"
                         },
+                        "targetPort": {
+                            "title": "Target port of the service to route traffic to.",
+                            "type": "string",
+                            "default": "http-backend"
+                        },
                         "wildcardPolicy": {
                             "title": "Wildcard policy if any for the route.",
                             "type": "string",

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -393,6 +393,7 @@ openshift:
     host: "{{ .Values.host }}"
     path: "/"
     wildcardPolicy: "None"
+    targetPort: "http-backend"
     tls:
       enabled: true
       termination: "edge"


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

In the legacy `backstage` chart, there was a way to change the target port of the RHDH route on OpenShift. That was useful in case of the oauth2-proxy auth provider introduced as extra container.

In the new standalone `rhdh` chart, the target port is hard-coded to be `http-backend`

This PR introduces a chart value `opehshift.route.targetPort` (with a default value of `http-backend`) that allows changing route's the target port.

## Which issue(s) does this PR fix or relate to

<!-- List any related issues. -->

- _JIRA_issue_link_

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
