### PR TITLE
chore(intelligent-assistant): change intelligent assistant (lightspeed) configs repository

### DIFF
--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -148,7 +148,7 @@ jobs:
             SYNCED_FILES=$(git diff --name-only HEAD~1 -- "${FILES_DIR}" | sed 's/^/- `/;s/$/`/')
 
             BODY=$(cat <<EOF
-          Automated nightly sync of Lightspeed Core config files from [redhat-ai-dev/lightspeed-configs @ ${TARGET_BRANCH}](https://github.com/redhat-ai-dev/lightspeed-configs/tree/${TARGET_BRANCH}).
+          Automated nightly sync of Lightspeed Core config files from [redhat-developer/rhdh-intelligent-assistant-configs @ ${TARGET_BRANCH}](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs/tree/${TARGET_BRANCH}).
 
           Bumped chart version to **${NEW_VERSION}**.
 

--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -132,6 +132,11 @@ jobs:
         run: |
           TITLE="chore(intelligent-assistant): sync Lightspeed Core config files and bump chart to ${NEW_VERSION}"
           BRANCH="chore/sync-lightspeed-configs-${TARGET_BRANCH}"
+          TARGET_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
+
+          if [[ "${TARGET_BRANCH}" == "release-1.10" ]]; then
+            TARGET_BRANCH="redhat-ai-dev/lightspeed-configs"
+          fi
 
           EXISTING_PR=$(gh pr list --head "${BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // empty')
 
@@ -153,7 +158,7 @@ jobs:
             SYNCED_FILES=$(git diff --name-only HEAD~1 -- "${FILES_DIR}" | sed 's/^/- `/;s/$/`/')
 
             BODY=$(cat <<EOF
-          Automated nightly sync of Lightspeed Core config files from [redhat-developer/rhdh-intelligent-assistant-configs @ ${TARGET_BRANCH}](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs/tree/${TARGET_BRANCH}).
+          Automated nightly sync of Lightspeed Core config files from [${TARGET_REPO} @ ${TARGET_BRANCH}](https://github.com/${TARGET_REPO}/tree/${TARGET_BRANCH}).
 
           Bumped chart version to **${NEW_VERSION}**.
 

--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -135,7 +135,7 @@ jobs:
           TARGET_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
 
           if [[ "${TARGET_BRANCH}" == "release-1.10" ]]; then
-            TARGET_BRANCH="redhat-ai-dev/lightspeed-configs"
+            TARGET_REPO="redhat-ai-dev/lightspeed-configs"
           fi
 
           EXISTING_PR=$(gh pr list --head "${BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -78,7 +78,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Sync Lightspeed Core config files
-        run: ./hack/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+        run: |
+          if [[ "${{ matrix.branch }}" == "release-1.10" ]]; then
+            ./hack/sync-lightspeed-configs.sh --repo redhat-ai-dev/lightspeed-configs --ref ${{ matrix.branch }}
+          else
+            ./hack/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+          fi
 
       - name: Check for changes
         id: changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before making a contribution to the charts in this repository, you will need to 
 
 ## Sync Lightspeed Core vendored config files
 
-The Lightspeed Core config files under [`charts/rhdh/files/intelligent-assistant`](./charts/rhdh/files/intelligent-assistant) are synced from the upstream [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) repository by [`hack/sync-lightspeed-configs.sh`](./hack/sync-lightspeed-configs.sh).
+The Lightspeed Core config files under [`charts/rhdh/files/intelligent-assistant`](./charts/rhdh/files/intelligent-assistant) are synced from the upstream [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) repository by [`hack/sync-lightspeed-configs.sh`](./hack/sync-lightspeed-configs.sh).
 
 Use the default upstream branch:
 

--- a/hack/sync-lightspeed-configs.sh
+++ b/hack/sync-lightspeed-configs.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DEFAULT_REPO="redhat-ai-dev/lightspeed-configs"
+DEFAULT_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
 DEFAULT_REF="main"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to link any JIRA issue(s) that this PR closes or relates to, as this helps provide more context to reviewers.

-->

## Description of the change

We have migrated [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) to [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) for all upcoming feature releases of RHDH. Starting with RHDH 2.1, the intelligent assistant (lightspeed) configs will be fetched from [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs).

**Note**: [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) will be kept active for RHDH 1.10 support, **do not backport this change**.

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-14891 **(Developer Week)**

## How to test changes / Special notes to the reviewer

Run `bash hack/sync-lightspeed-configs.sh` to test syncing the content. Changes from this script are not part of this PR's scope however.

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
