### PR TITLE
fix(must-gather): add missing RBAC rules for namespace-inspect resources [RHDHBUGS-3739]

### DIFF
--- a/charts/must-gather/Chart.yaml
+++ b/charts/must-gather/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Note that when this chart is published to https://github.com/openshift-helm-charts/charts
 # it will follow the RHDH versioning 1.y.z
-version: 0.6.0
+version: 0.7.0

--- a/charts/must-gather/README.md
+++ b/charts/must-gather/README.md
@@ -1,7 +1,7 @@
 
 # Must Gather Chart for Red Hat Developer Hub (RHDH)
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for running the RHDH Must-Gather diagnostic tool on Kubernetes
@@ -27,7 +27,7 @@ Kubernetes: `>= 1.27.0-0`
 ```console
 helm upgrade --install my-rhdh-must-gather redhat-developer-hub-must-gather \
   --repo https://redhat-developer.github.io/rhdh-chart \
-  --version 0.6.0 \
+  --version 0.7.0 \
   [--wait --timeout=$duration]
 ```
 
@@ -141,12 +141,13 @@ The command removes all the Kubernetes resources associated with the chart and d
 | podAnnotations | Pod annotations | object | `{}` |
 | podLabels | Pod labels | object | `{}` |
 | podSecurityContext | Pod security context | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` |
-| rbac | RBAC configuration | object | `{"create":true,"rules":{"backstages":true,"ingresses":true,"knative":true,"olm":true,"platform":true,"routes":true,"sonataflow":true},"scope":"cluster"}` |
+| rbac | RBAC configuration | object | `{"create":true,"rules":{"backstages":true,"ingresses":true,"knative":true,"monitoring":true,"olm":true,"platform":true,"routes":true,"sonataflow":true},"scope":"cluster"}` |
 | rbac.create | Create RBAC resources (Role/ClusterRole and bindings) | bool | `true` |
-| rbac.rules | a rule here does not require disabling the corresponding gather.with* flag. | object | `{"backstages":true,"ingresses":true,"knative":true,"olm":true,"platform":true,"routes":true,"sonataflow":true}` |
+| rbac.rules | a rule here does not require disabling the corresponding gather.with* flag. | object | `{"backstages":true,"ingresses":true,"knative":true,"monitoring":true,"olm":true,"platform":true,"routes":true,"sonataflow":true}` |
 | rbac.rules.backstages | rhdh.redhat.com — Backstage custom resources | bool | `true` |
 | rbac.rules.ingresses | networking.k8s.io — Ingresses, NetworkPolicies | bool | `true` |
 | rbac.rules.knative | operator.knative.dev, operator.serverless.openshift.io — Knative/Serverless | bool | `true` |
+| rbac.rules.monitoring | monitoring.coreos.com — ServiceMonitors (Prometheus Operator) | bool | `true` |
 | rbac.rules.olm | operators.coreos.com — OLM resources (subscriptions, CSVs, etc.) | bool | `true` |
 | rbac.rules.platform | config.openshift.io — ClusterVersions, Infrastructures (cluster scope only) | bool | `true` |
 | rbac.rules.routes | route.openshift.io — OpenShift Routes | bool | `true` |

--- a/charts/must-gather/templates/clusterrbac.yaml
+++ b/charts/must-gather/templates/clusterrbac.yaml
@@ -33,6 +33,18 @@ rules:
     resources: ["ingresses", "networkpolicies", "ingressclasses"]
     verbs: ["get", "list"]
   {{- end }}
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list"]
   {{- if .Values.rbac.rules.routes }}
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
@@ -76,6 +88,11 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["operator.serverless.openshift.io"]
     resources: ["knativekafkas"]
+    verbs: ["get", "list"]
+  {{- end }}
+  {{- if .Values.rbac.rules.monitoring }}
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors"]
     verbs: ["get", "list"]
   {{- end }}
 ---

--- a/charts/must-gather/templates/rbac.yaml
+++ b/charts/must-gather/templates/rbac.yaml
@@ -26,6 +26,18 @@ rules:
     resources: ["ingresses", "networkpolicies"]
     verbs: ["get", "list"]
   {{- end }}
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list"]
   {{- if .Values.rbac.rules.routes }}
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
@@ -63,6 +75,11 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["operator.serverless.openshift.io"]
     resources: ["knativekafkas"]
+    verbs: ["get", "list"]
+  {{- end }}
+  {{- if .Values.rbac.rules.monitoring }}
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors"]
     verbs: ["get", "list"]
   {{- end }}
 ---

--- a/charts/must-gather/values.schema.json
+++ b/charts/must-gather/values.schema.json
@@ -1354,6 +1354,11 @@
                             "title": "operator.knative.dev, operator.serverless.openshift.io \u2014 Knative/Serverless.",
                             "type": "boolean"
                         },
+                        "monitoring": {
+                            "default": true,
+                            "title": "monitoring.coreos.com \u2014 ServiceMonitors (Prometheus Operator).",
+                            "type": "boolean"
+                        },
                         "olm": {
                             "default": true,
                             "title": "operators.coreos.com \u2014 OLM resources (subscriptions, CSVs, etc.).",

--- a/charts/must-gather/values.schema.tmpl.json
+++ b/charts/must-gather/values.schema.tmpl.json
@@ -141,6 +141,11 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "monitoring": {
+                            "title": "monitoring.coreos.com — ServiceMonitors (Prometheus Operator).",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "platform": {
                             "title": "config.openshift.io — ClusterVersions, Infrastructures (cluster scope only).",
                             "type": "boolean",

--- a/charts/must-gather/values.yaml
+++ b/charts/must-gather/values.yaml
@@ -56,6 +56,8 @@ rbac:
     knative: true
     # -- networking.k8s.io — Ingresses, NetworkPolicies
     ingresses: true
+    # -- monitoring.coreos.com — ServiceMonitors (Prometheus Operator)
+    monitoring: true
     # -- config.openshift.io — ClusterVersions, Infrastructures (cluster scope only)
     platform: true
 


### PR DESCRIPTION
## Description of the change

The `oc adm inspect` library collects several resource types that the must-gather ServiceAccount did not have permissions for, causing silent collection gaps during namespace inspection. These gaps existed in the previous shell-based implementation as well, but the permission errors were not surfaced prominently.

Changes:
- Add always-included RBAC rules for `horizontalpodautoscalers` (autoscaling), `endpointslices` (discovery.k8s.io), and `poddisruptionbudgets` (policy) to both Role and ClusterRole
- Add toggleable `monitoring.coreos.com/servicemonitors` rule gated by `rbac.rules.monitoring` (defaults to `true`)
- Update JSON schema template and generated schema
- Bump chart version from 0.6.0 to 0.7.0

## Which issue(s) does this PR fix or relate to

Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3739

## How to test changes / Special notes to the reviewer

This was discovered while testing the must-gather image from the rewrite PR: https://github.com/redhat-developer/rhdh-must-gather/pull/347

## Checklist

- [x] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [x] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [x] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.