### PR TITLE
chore(intelligent-assistant): change configs repository ref under `docs/intelligent-assistant.md`

### DIFF
--- a/docs/intelligent-assistant.md
+++ b/docs/intelligent-assistant.md
@@ -251,7 +251,7 @@ OKP values are under `intelligentAssistant.okp.*`:
 ## Lightspeed Config Sync
 
 Vendored config files in `charts/rhdh/files/intelligent-assistant/` are synced from the upstream
-[lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) repository:
+[rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) repository:
 
 ```bash
 hack/sync-lightspeed-configs.sh            # sync from main


### PR DESCRIPTION
## Description of the change

https://github.com/redhat-developer/rhdh-chart/pull/521 updated redhat-ai-dev/lightspeed-configs references to redhat-developer/rhdh-intelligent-assistant-configs new repository location. https://github.com/redhat-developer/rhdh-chart/pull/500 being older left out revisions to this location, this PR addresses it.

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-14891 **(Developer Week)**

## How to test changes / Special notes to the reviewer

<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Checklist

- [ ] For each Chart updated, version bumped in the corresponding `Chart.yaml` according to [Semantic Versioning](http://semver.org/).
- [ ] For each Chart updated, variables are documented in the `values.yaml` and added to the corresponding README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Run `pre-commit run --all-files` to run the hooks and then push any resulting changes. The [pre-commit Workflow](./workflows/pre-commit.yaml) will enforce this and warn you if needed.
- [ ] JSON Schema template updated and re-generated the raw schema via the `pre-commit` hook.
- [ ] Tests pass using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
- [ ] If you updated the [orchestrator-infra](../charts/orchestrator-infra) chart, make sure the versions of the [Knative CRDs](../charts/orchestrator-infra/crds) are aligned with the versions of the CRDs installed by the OpenShift Serverless operators declared in the [values.yaml](../charts/orchestrator-infra/values.yaml) file. See [Installing Knative Eventing and Knative Serving CRDs](../charts/orchestrator-infra/README.md#installing-knative-eventing-and-knative-serving-crds) for more details.
